### PR TITLE
Implement squad drag to formation grid

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -144,7 +144,14 @@ export class Game {
         const formationSpacing = this.mapManager.tileSize * 2.5;
         this.formationManager = new FormationManager(5, 5, formationSpacing);
         this.eventManager.subscribe('formation_assign_request', d => {
-            this.formationManager.assign(d.slotIndex, d.entityId);
+            if (d.squadId) {
+                const squad = this.squadManager.getSquad(d.squadId);
+                if (squad) {
+                    squad.members.forEach(id => this.formationManager.assign(d.slotIndex, id));
+                }
+            } else {
+                this.formationManager.assign(d.slotIndex, d.entityId);
+            }
             this.uiManager?.createSquadManagementUI();
         });
         this.saveLoadManager = new SaveLoadManager();

--- a/src/managers/formationManager.js
+++ b/src/managers/formationManager.js
@@ -5,20 +5,23 @@ export class FormationManager {
         this.cols = Math.max(1, Math.floor(Number(cols) || 5));
         this.tileSize = tileSize;
         this.orientation = orientation; // LEFT or RIGHT
-        this.slots = Array(this.rows * this.cols).fill(null); // entity ids
+        this.slots = Array.from({ length: this.rows * this.cols }, () => new Set());
     }
 
     resize(rows, cols) {
         this.rows = Math.max(1, Math.floor(Number(rows) || this.rows));
         this.cols = Math.max(1, Math.floor(Number(cols) || this.cols));
-        this.slots = Array(this.rows * this.cols).fill(null);
+        this.slots = Array.from({ length: this.rows * this.cols }, () => new Set());
     }
 
     assign(slotIndex, entityId) {
         if (slotIndex < 0 || slotIndex >= this.slots.length) return;
-        const currentIndex = this.slots.indexOf(entityId);
-        if (currentIndex !== -1) this.slots[currentIndex] = null;
-        this.slots[slotIndex] = entityId;
+        this.slots.forEach(set => set.delete(entityId));
+        this.slots[slotIndex].add(entityId);
+    }
+
+    findSlotIndex(entityId) {
+        return this.slots.findIndex(set => set.has(entityId));
     }
 
     getSlotPosition(slotIndex) {
@@ -39,16 +42,16 @@ export class FormationManager {
     }
 
     apply(origin, entityMap) {
-        this.slots.forEach((id, idx) => {
-            if (!id) return;
-            const ent = entityMap[id];
-            if (ent) {
-                const off = this.getSlotPosition(idx);
-                const randomOffsetX = (Math.random() - 0.5) * this.tileSize * 0.5;
-                const randomOffsetY = (Math.random() - 0.5) * this.tileSize * 0.5;
-                ent.x = origin.x + off.x + randomOffsetX;
-                ent.y = origin.y + off.y + randomOffsetY;
-            }
+        this.slots.forEach((set, idx) => {
+            if (!set) return;
+            const off = this.getSlotPosition(idx);
+            set.forEach(id => {
+                const ent = entityMap[id];
+                if (ent) {
+                    ent.x = origin.x + off.x;
+                    ent.y = origin.y + off.y;
+                }
+            });
         });
     }
 }

--- a/tests/unit/enemyFormationManager.test.js
+++ b/tests/unit/enemyFormationManager.test.js
@@ -9,7 +9,7 @@ describe('EnemyFormationManager', () => {
         const m2 = { id: 'm2', ai: new RangedAI() };
         const m3 = { id: 'm3', ai: new HealerAI() };
         fm.arrange([m1, m2, m3]);
-        const rowOf = id => Math.floor(fm.slots.indexOf(id) / fm.cols);
+        const rowOf = id => Math.floor(fm.findSlotIndex(id) / fm.cols);
         assert.equal(rowOf(m1.id), 0);
         assert.equal(rowOf(m2.id), 1);
         assert.equal(rowOf(m3.id), 2);

--- a/tests/unit/formationManager.test.js
+++ b/tests/unit/formationManager.test.js
@@ -9,5 +9,13 @@ describe('FormationManager', () => {
         assert.equal(pos.x, 0);
         assert.equal(pos.y, 0);
     });
+
+    test('multiple entities in one slot', () => {
+        const fm = new FormationManager(2,2,10);
+        fm.assign(0, 'A');
+        fm.assign(0, 'B');
+        assert.deepEqual(Array.from(fm.slots[0]), ['A','B']);
+        assert.equal(fm.findSlotIndex('B'), 0);
+    });
 });
 


### PR DESCRIPTION
## Summary
- allow multiple units per formation slot
- support dropping whole squads on the formation grid
- spawn squad members from the same grid position
- update unit tests for new formation behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c56a330448327a098a53423fdf8fb