### PR TITLE
Fix formation grid rotation

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -142,7 +142,8 @@ export class Game {
         this.laneManager = new LaneManager(mapPixelWidth, mapPixelHeight, laneCenters);
         this.laneRenderManager = new LaneRenderManager(this.laneManager, SETTINGS.ENABLE_AQUARIUM_LANES);
         const formationSpacing = this.mapManager.tileSize * 2.5;
-        this.formationManager = new FormationManager(5, 5, formationSpacing);
+        const formationAngle = -Math.PI / 4; // align grid with battlefield orientation
+        this.formationManager = new FormationManager(5, 5, formationSpacing, 'LEFT', formationAngle);
         this.eventManager.subscribe('formation_assign_request', d => {
             if (d.squadId) {
                 const squad = this.squadManager.getSquad(d.squadId);
@@ -351,7 +352,7 @@ export class Game {
         this.monsterGroup = this.metaAIManager.createGroup('dungeon_monsters', STRATEGY.AGGRESSIVE);
 
         // === 몬스터 부대 생성 ===
-        const enemyFormationManager = new FormationManager(5, 5, formationSpacing, 'RIGHT');
+        const enemyFormationManager = new FormationManager(5, 5, formationSpacing, 'RIGHT', formationAngle);
         const enemyFormationOrigin = {
             x: (this.mapManager.width - 8) * this.mapManager.tileSize,
             y: (this.mapManager.height / 2) * this.mapManager.tileSize,

--- a/src/managers/formationManager.js
+++ b/src/managers/formationManager.js
@@ -1,10 +1,11 @@
 export class FormationManager {
-    constructor(rows = 5, cols = 5, tileSize = 192, orientation = 'LEFT') {
+    constructor(rows = 5, cols = 5, tileSize = 192, orientation = 'LEFT', rotation = 0) {
         // sanitize parameters to avoid invalid array length errors
         this.rows = Math.max(1, Math.floor(Number(rows) || 5));
         this.cols = Math.max(1, Math.floor(Number(cols) || 5));
         this.tileSize = tileSize;
         this.orientation = orientation; // LEFT or RIGHT
+        this.rotation = rotation; // radian angle to rotate grid positions
         this.slots = Array.from({ length: this.rows * this.cols }, () => new Set());
     }
 
@@ -37,8 +38,12 @@ export class FormationManager {
 
         const relativeX = (col - centerCol) * this.tileSize * orientationMultiplier;
         const relativeY = (row - centerRow) * this.tileSize;
+        const cos = Math.cos(this.rotation);
+        const sin = Math.sin(this.rotation);
+        const rotatedX = relativeX * cos - relativeY * sin;
+        const rotatedY = relativeX * sin + relativeY * cos;
 
-        return { x: relativeX, y: relativeY };
+        return { x: rotatedX, y: rotatedY };
     }
 
     apply(origin, entityMap) {


### PR DESCRIPTION
## Summary
- rotate formation slots so the arrangement matches battlefield orientation
- align formation managers with the new rotation angle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c5a6fb9a88327a5f3a42f8bae45ba