### PR TITLE
Add tooltip system and inventory UI

### DIFF
--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -7,9 +7,133 @@ export class UIManager {
         this.squads = [];
         this.formationManager = null;
 
+        // 툴팁 엘리먼트 생성 및 초기화
+        this.tooltipElement = document.createElement('div');
+        this.tooltipElement.id = 'game-tooltip';
+        this.tooltipElement.style.display = 'none';
+        document.body.appendChild(this.tooltipElement);
+
+        // 이벤트 구독
         this.eventManager.subscribe('squads_updated', this.handleSquadsUpdate.bind(this));
         this.eventManager.subscribe('formation_updated', this.handleFormationUpdate.bind(this));
+        // 플레이어 인벤토리가 업데이트될 때 호출될 이벤트 구독 추가
+        this.eventManager.subscribe('player_inventory_updated', this.renderPlayerInventory.bind(this));
     }
+
+    /**
+     * 상세 툴팁을 생성하고 마우스 커서 주변에 표시합니다.
+     * @param {MouseEvent} event - 마우스 이벤트
+     * @param {string} htmlContent - 툴팁에 표시될 HTML 콘텐츠
+     */
+    showTooltip(event, htmlContent) {
+        this.tooltipElement.innerHTML = htmlContent;
+        this.tooltipElement.style.display = 'block';
+        this.updateTooltipPosition(event);
+    }
+
+    /**
+     * 툴팁을 숨깁니다.
+     */
+    hideTooltip() {
+        this.tooltipElement.style.display = 'none';
+    }
+
+    /**
+     * 마우스 움직임에 따라 툴팁 위치를 업데이트합니다.
+     * @param {MouseEvent} event - 마우스 이벤트
+     */
+    updateTooltipPosition(event) {
+        // 툴팁이 화면 가장자리를 벗어나지 않도록 처리
+        const tooltipRect = this.tooltipElement.getBoundingClientRect();
+        let left = event.pageX + 15;
+        let top = event.pageY + 15;
+
+        if (left + tooltipRect.width > window.innerWidth) {
+            left = window.innerWidth - tooltipRect.width - 15;
+        }
+        if (top + tooltipRect.height > window.innerHeight) {
+            top = window.innerHeight - tooltipRect.height - 15;
+        }
+
+        this.tooltipElement.style.left = `${left}px`;
+        this.tooltipElement.style.top = `${top}px`;
+    }
+
+    /**
+     * 아이템의 상세 정보를 바탕으로 툴팁에 들어갈 HTML을 생성합니다.
+     * @param {object} item - 상세 정보가 필요한 아이템 객체
+     * @returns {string} - 툴팁용 HTML 문자열
+     */
+    generateItemTooltipHTML(item) {
+        if (!item) return '';
+
+        // 아이템 희귀도에 따라 이름 색상을 다르게 할 수 있습니다. (예시)
+        const rarityColor = item.rarity === 'legendary' ? 'orange' : 'white';
+        let html = `<h3 style="color: ${rarityColor};">${item.name}</h3>`;
+        html += `<p>타입: ${item.type || '일반'}</p>`;
+
+        if (item.stats && Object.keys(item.stats).length > 0) {
+            html += '<h4>능력치</h4><ul>';
+            for (const [stat, value] of Object.entries(item.stats)) {
+                html += `<li>${stat}: ${value}</li>`;
+            }
+            html += '</ul>';
+        }
+
+        if (item.affixes && item.affixes.length > 0) {
+            html += '<h4>특수 효과</h4><ul>';
+            item.affixes.forEach(affix => {
+                html += `<li>${affix}</li>`;
+            });
+            html += '</ul>';
+        }
+
+        if (item.synergy) {
+            html += `<h4>시너지</h4><p>${item.synergy.description || '없음'}</p>`;
+        }
+
+        return html;
+    }
+
+    /**
+     * 플레이어의 인벤토리 UI를 렌더링합니다.
+     * @param {object} data - { inventory: string[] } 형태의 인벤토리 아이템 ID 목록
+     */
+    renderPlayerInventory({ inventory }) {
+        // HTML에 <div id="inventory-panel"></div> 가 있다고 가정합니다.
+        const inventoryPanel = document.getElementById('inventory-panel');
+        if (!inventoryPanel) {
+            console.warn('UI: inventory-panel not found!');
+            return;
+        }
+
+        inventoryPanel.innerHTML = '';
+
+        (inventory || []).forEach(itemId => {
+            const item = this.entityManager.getEntity(itemId);
+            if (item) {
+                const itemSlot = document.createElement('div');
+                itemSlot.className = 'item-slot';
+                itemSlot.textContent = item.name.substring(0, 1); // 아이템 이름 첫 글자 표시
+
+                // 각 아이템 슬롯에 툴팁 이벤트 리스너 추가
+                itemSlot.addEventListener('mouseover', (e) => {
+                    const tooltipContent = this.generateItemTooltipHTML(item);
+                    this.showTooltip(e, tooltipContent);
+                });
+                itemSlot.addEventListener('mouseout', () => {
+                    this.hideTooltip();
+                });
+                itemSlot.addEventListener('mousemove', (e) => {
+                    this.updateTooltipPosition(e);
+                });
+
+                inventoryPanel.appendChild(itemSlot);
+            }
+        });
+    }
+
+    // --- 여기에 이전 답변의 squad, formation 관련 메서드들이 와야 합니다. ---
 
     handleSquadsUpdate({ squads }) {
         this.squads = squads;
@@ -88,7 +212,7 @@ export class UIManager {
 
         return portrait;
     }
-    
+
     addDropHandler(cell) {
         cell.addEventListener('dragover', e => e.preventDefault());
         cell.addEventListener('drop', e => {

--- a/style.css
+++ b/style.css
@@ -562,3 +562,48 @@ body, html {
     font-size: 14px;
     color: #ccc;
 }
+
+/* ==================
+   Tooltip Styles
+   ================== */
+#game-tooltip {
+    position: absolute; /* 마우스 위치를 따라다니기 위해 absolute 사용 */
+    background-color: rgba(20, 20, 30, 0.9);
+    color: #f0f0f0;
+    border: 1px solid #6677aa;
+    border-radius: 6px;
+    padding: 12px;
+    z-index: 1000; /* 다른 UI 요소들보다 위에 표시 */
+    pointer-events: none; /* 툴팁이 마우스 이벤트를 가로채지 않도록 설정 */
+    max-width: 320px;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    font-size: 14px;
+    line-height: 1.6;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.4);
+    transition: opacity 0.1s ease-in-out;
+}
+
+#game-tooltip h3 {
+    margin: 0 0 8px 0;
+    font-size: 16px;
+    font-weight: bold;
+    border-bottom: 1px solid #445588;
+    padding-bottom: 5px;
+}
+
+#game-tooltip p {
+    margin: 0 0 5px 0;
+}
+
+#game-tooltip h4 {
+    margin: 12px 0 6px 0;
+    color: #aaddff;
+    font-size: 14px;
+    font-weight: bold;
+}
+
+#game-tooltip ul {
+    margin: 0;
+    padding-left: 20px;
+    list-style-type: '– '; /* 리스트 마커 변경 */
+}


### PR DESCRIPTION
## Summary
- implement tooltip generation and positioning in `UIManager`
- render player inventory slots with dynamic tooltips
- subscribe to `player_inventory_updated` event
- style tooltip element in `style.css`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685caa97cee08327908c893b1a59fd2c