### PR TITLE
Fix missing EntityManager.getAllEntities

### DIFF
--- a/src/managers/entityManager.js
+++ b/src/managers/entityManager.js
@@ -51,4 +51,8 @@ export class EntityManager {
     getMonsters() {
         return this.monsters;
     }
+
+    getAllEntities() {
+        return Array.from(this.entities.values());
+    }
 }


### PR DESCRIPTION
## Summary
- add missing `getAllEntities` to `EntityManager`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cbb6440888327941c7a06acea4cd8