### PR TITLE
Add starting inventory with all weapons

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -9,6 +9,9 @@ import { BgmManager } from './managers/bgmManager.js';
 import { SoundManager } from './managers/soundManager.js';
 import { Player } from './entities/player.js';
 import { Mercenary } from './entities/mercenary.js';
+import { createGridInventory } from './inventory.js';
+import { ITEMS } from './data/items.js';
+import { ItemFactory } from './factory.js';
 
 export class Game {
     constructor() {
@@ -19,7 +22,8 @@ export class Game {
         this.uiManager = new UIManager(this.eventManager, this.entityManager);
         this.soundManager = new SoundManager(this.eventManager);
         this.bgmManager = new BgmManager(this.eventManager);
-        
+        this.itemFactory = new ItemFactory({});
+
         console.log("Game and managers initialized.");
     }
 
@@ -37,7 +41,21 @@ export class Game {
     createInitialEntities() {
         // 플레이어 생성
         const player = new Player({ id: 'player', name: 'Player' });
+        player.inventory = createGridInventory(6, 6);
         this.entityManager.addEntity(player);
+
+        const weaponIds = Object.keys(ITEMS).filter(id => ITEMS[id].type === 'weapon');
+        for (const wId of weaponIds) {
+            const weapon = this.itemFactory.create(wId, 0, 0, 32);
+            if (weapon) {
+                player.inventory.push(weapon);
+                this.entityManager.addEntity(weapon);
+            }
+        }
+
+        this.eventManager.publish('player_inventory_updated', {
+            inventory: player.inventory.toArray().filter(Boolean).map(i => i.id)
+        });
 
         // 용병 생성
         for (let i = 1; i <= 5; i++) {


### PR DESCRIPTION
## Summary
- populate the player's inventory on game start
- load every weapon from `ITEMS` into the new inventory grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cc2547c9883278e2123a2ecf7ddff