### PR TITLE
Add world map generation step

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -36,6 +36,8 @@ export class Game {
     start() {
         console.log("Starting game...");
         this._loadAssets(() => {
+            // 월드맵을 50x50 크기로 생성합니다.
+            this.mapManager.generateMap(50, 50);
             this.createInitialEntities();
             this.squadManager.createInitialSquads();
 

--- a/src/map.js
+++ b/src/map.js
@@ -18,6 +18,13 @@ export class MapManager {
         this.map = this._generateMaze();
     }
 
+    generateMap(width = this.width, height = this.height) {
+        this.width = width;
+        this.height = height;
+        this.rooms = [];
+        this.map = this._generateMaze();
+    }
+
     _random() {
         const a = 1664525;
         const c = 1013904223;


### PR DESCRIPTION
## Summary
- generate world map with 50x50 tiles on game start
- expose `generateMap` helper in MapManager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cf122f77083279ab6b1829dceb47c