### PR TITLE
Add start weapons and simplify tooltip

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,7 +185,6 @@
         <div class="skill-slot" data-slot-index="2"><span>3</span></div>
     </div>
 
-    <div id="tooltip" class="tooltip ui-frame hidden"></div>
 
     <script type="module" src="main.js"></script>
 </body>

--- a/src/game.js
+++ b/src/game.js
@@ -30,6 +30,7 @@ import { KnockbackEngine } from './systems/KnockbackEngine.js';
 import { SupportEngine } from './systems/SupportEngine.js';
 import { SKILLS } from './data/skills.js';
 import { EFFECTS } from './data/effects.js';
+import { ITEMS } from './data/items.js';
 import { Item } from './entities.js';
 import { rollOnTable } from './utils/random.js';
 import { getMonsterLootTable } from './data/tables.js';
@@ -231,10 +232,12 @@ export class Game {
         this.equipmentManager.setTagManager(this.tagManager);
 
         this.itemFactory = new ItemFactory(assets);
-        const eagerSword = this.itemFactory.create('eager_sword', 0, 0, this.mapManager.tileSize);
-        if (eagerSword) {
-            this.inventoryManager.getSharedInventory().push(eagerSword);
-        }
+        // 게임 시작 시 무기 아이템들을 한 개씩 고용 인벤토리에 배치합니다.
+        const weaponIds = Object.keys(ITEMS).filter(id => ITEMS[id].type === 'weapon');
+        weaponIds.forEach(id => {
+            const weapon = this.itemFactory.create(id, 0, 0, this.mapManager.tileSize);
+            if (weapon) this.inventoryManager.getSharedInventory().push(weapon);
+        });
         this.pathfindingManager = new PathfindingManager(this.mapManager);
         this.motionManager = new Managers.MotionManager(this.mapManager, this.pathfindingManager);
         this.knockbackEngine = new KnockbackEngine(this.motionManager, this.vfxManager);

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -52,6 +52,7 @@ export class UIManager {
         this.squadManagementPanel = document.getElementById('squad-management-ui');
         this._squadUIInitialized = false;
         this.formationManager = null;
+        // 특정 HTML 요소가 존재하면 커스텀 툴팁을 사용합니다.
         this.tooltip = document.getElementById('tooltip');
         this.characterSheetTemplate = document.getElementById('character-sheet-template');
         this.uiContainer = document.getElementById('ui-container');
@@ -620,17 +621,23 @@ export class UIManager {
     }
 
     _attachTooltip(element, html) {
-        if (!this.tooltip) return;
-        element.onmouseenter = (e) => {
-            this.tooltip.innerHTML = html;
-            this.tooltip.style.left = `${e.pageX + 10}px`;
-            this.tooltip.style.top = `${e.pageY + 10}px`;
-            this.tooltip.classList.remove('hidden');
-        };
-        element.onmouseleave = () => this.tooltip.classList.add('hidden');
-        element.onmousemove = (e) => {
-             this.tooltip.style.left = `${e.pageX + 10}px`;
-             this.tooltip.style.top = `${e.pageY + 10}px`;
+        // 툴팁 요소가 존재하면 커스텀 툴팁을 사용하고, 없으면 기본 title 특성을 사용합니다.
+        if (this.tooltip) {
+            element.onmouseenter = (e) => {
+                this.tooltip.innerHTML = html;
+                this.tooltip.style.left = `${e.pageX + 10}px`;
+                this.tooltip.style.top = `${e.pageY + 10}px`;
+                this.tooltip.classList.remove('hidden');
+            };
+            element.onmouseleave = () => this.tooltip.classList.add('hidden');
+            element.onmousemove = (e) => {
+                this.tooltip.style.left = `${e.pageX + 10}px`;
+                this.tooltip.style.top = `${e.pageY + 10}px`;
+            };
+        } else {
+            // HTML 태그를 제거하고 기본 title 속성으로 보여준다
+            const text = html.replace(/<br\s*\/?>/gi, '\n').replace(/<[^>]+>/g, '');
+            element.title = text;
         }
     }
 

--- a/style.css
+++ b/style.css
@@ -73,19 +73,6 @@ body, html {
     overflow-y: auto;
 }
 
-/* 툴팁 (최상위) */
-.tooltip {
-    position: fixed;
-    z-index: 300;
-    color: #fff;
-    padding: 6px 8px;
-    border-radius: 4px;
-    pointer-events: none;
-    font-size: 12px;
-    max-width: 200px;
-}
-
-
 /* 공통 UI 프레임 스타일 */
 .ui-frame {
     border: 20px solid transparent;


### PR DESCRIPTION
## Summary
- give all weapons once in the shared hire inventory when the game initializes
- delete unused tooltip container from HTML and style sheet
- fallback to `title` attribute tooltip when no custom tooltip element exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cfff9e3248327b36a3adb30a50e4d