### PR TITLE
Add TooltipManager and integrate with UI

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -57,6 +57,7 @@ import { LaneRenderManager } from './managers/laneRenderManager.js';
 import { LanePusherAI } from './ai/archetypes.js';
 import { LaneAssignmentManager } from './managers/laneAssignmentManager.js';
 import { FormationManager } from './managers/formationManager.js';
+import { TooltipManager } from './managers/tooltipManager.js';
 
 export class Game {
     constructor() {
@@ -128,6 +129,7 @@ export class Game {
 
         // === 1. 모든 매니저 및 시스템 생성 ===
         this.eventManager = new EventManager();
+        this.tooltipManager = new TooltipManager();
         this.entityManager = new EntityManager(this.eventManager);
         this.inputHandler = new InputHandler(this.eventManager, this);
         this.combatLogManager = new CombatLogManager(this.eventManager);
@@ -192,7 +194,11 @@ export class Game {
         );
         for (const managerName of otherManagerNames) {
             if (managerName === 'UIManager') {
-                this.managers[managerName] = new Managers.UIManager(this.eventManager, (id) => this.entityManager?.getEntityById(id));
+                this.managers[managerName] = new Managers.UIManager(
+                    this.eventManager,
+                    (id) => this.entityManager?.getEntityById(id),
+                    this.tooltipManager
+                );
             } else {
                 this.managers[managerName] = new Managers[managerName](this.eventManager, assets, this.factory);
             }

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -39,6 +39,7 @@ import { CombatDecisionEngine } from './ai/CombatDecisionEngine.js';
 import { ReputationManager } from './ReputationManager.js';
 import { EntityManager } from './entityManager.js';
 import GuidelineLoader from './guidelineLoader.js';
+import { TooltipManager } from './tooltipManager.js';
 // DataRecorder is only needed in a Node.js environment so we lazy-load it
 let DataRecorder = null;
 if (typeof process !== 'undefined' && process.versions?.node) {
@@ -88,5 +89,6 @@ export {
     CombatDecisionEngine,
     GuidelineLoader,
     StatusEffectsManager,
+    TooltipManager,
     DataRecorder,
 };

--- a/src/managers/tooltipManager.js
+++ b/src/managers/tooltipManager.js
@@ -1,0 +1,72 @@
+export class TooltipManager {
+    constructor() {
+        this.tooltipElement = document.getElementById('tooltip');
+        if (!this.tooltipElement) {
+            console.error('Tooltip element not found in the DOM!');
+        }
+    }
+
+    /**
+     * 툴팁을 표시합니다.
+     * @param {string} htmlContent - 툴팁에 표시될 HTML 내용
+     * @param {MouseEvent} event - 마우스 이벤트 객체
+     */
+    show(htmlContent, event) {
+        if (!this.tooltipElement) return;
+        this.tooltipElement.innerHTML = htmlContent;
+        this.tooltipElement.classList.remove('hidden');
+        this.updatePosition(event);
+    }
+
+    /**
+     * 툴팁을 숨깁니다.
+     */
+    hide() {
+        if (!this.tooltipElement) return;
+        this.tooltipElement.classList.add('hidden');
+    }
+
+    /**
+     * 마우스 위치에 따라 툴팁 위치를 업데이트합니다.
+     * @param {MouseEvent} event - 마우스 이벤트 객체
+     */
+    updatePosition(event) {
+        if (!this.tooltipElement) return;
+
+        let x = event.pageX + 10;
+        let y = event.pageY + 10;
+
+        // 툴팁이 화면 밖으로 나가지 않도록 위치 조정
+        const screenWidth = window.innerWidth;
+        const screenHeight = window.innerHeight;
+        const tooltipRect = this.tooltipElement.getBoundingClientRect();
+
+        if (x + tooltipRect.width > screenWidth) {
+            x = event.pageX - tooltipRect.width - 10;
+        }
+        if (y + tooltipRect.height > screenHeight) {
+            y = event.pageY - tooltipRect.height - 10;
+        }
+
+        this.tooltipElement.style.left = `${x}px`;
+        this.tooltipElement.style.top = `${y}px`;
+    }
+
+    /**
+     * 지정된 DOM 요소에 툴팁 표시/숨김 이벤트를 연결합니다.
+     * @param {HTMLElement} element - 이벤트를 연결할 요소
+     * @param {string | function} content - 툴팁에 표시할 내용 (문자열 또는 함수)
+     */
+    attach(element, content) {
+        element.addEventListener('mouseenter', (e) => {
+            const html = typeof content === 'function' ? content() : content;
+            this.show(html, e);
+        });
+        element.addEventListener('mouseleave', () => {
+            this.hide();
+        });
+        element.addEventListener('mousemove', (e) => {
+            this.updatePosition(e);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- create `TooltipManager` to centralize tooltip logic
- wire tooltip manager into `Game` initialization and manager exports
- rework `UIManager` to use `TooltipManager` for item and stat tooltips
- enable tooltip support on skill bar icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d2b7182588327b8436f25940551e6