### PR TITLE
Add CombatManager with aspiration checks

### DIFF
--- a/src/managers/combatManager.js
+++ b/src/managers/combatManager.js
@@ -1,0 +1,49 @@
+export class CombatManager {
+    constructor(eventManager = null, uiManager = null, aspirationManager = null) {
+        this.eventManager = eventManager;
+        this.uiManager = uiManager;
+        this.aspirationManager = aspirationManager;
+        this.isInCombat = false;
+        this.player = null;
+        this.enemy = null;
+        this.turn = 0;
+        this.combatLog = [];
+    }
+
+    addToLog(message) {
+        if (!this.combatLog) this.combatLog = [];
+        this.combatLog.push(message);
+        this.eventManager?.publish?.('log', { message });
+    }
+
+    processTurn() {
+        // Placeholder for turn processing logic
+        this.turn += 1;
+    }
+
+    startCombat(player, enemy) {
+        if (this.isInCombat) return;
+
+        console.log(`Combat started between ${player.name} and ${enemy.name}`);
+        this.isInCombat = true;
+        this.player = player;
+        this.enemy = enemy;
+        this.turn = 0;
+        this.combatLog = [];
+
+        // 전투에 참여하는 모든 캐릭터의 열망 상태를 확인합니다.
+        // 이 코드가 누락되어 열망 효과가 발동하지 않았습니다.
+        if (this.aspirationManager) {
+            this.aspirationManager.checkAspiration(this.player);
+            this.aspirationManager.checkAspiration(this.enemy);
+        }
+
+        this.eventManager?.publish?.('combatStarted', { player, enemy });
+        if (this.uiManager && typeof this.uiManager.showCombatUI === 'function') {
+            this.uiManager.showCombatUI(player, enemy);
+        }
+        this.addToLog(`${player.name} vs ${enemy.name}: Combat has begun!`);
+
+        this.processTurn();
+    }
+}

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -38,6 +38,7 @@ import { PossessionAIManager } from './possessionAIManager.js';
 import { CombatDecisionEngine } from './ai/CombatDecisionEngine.js';
 import { ReputationManager } from './ReputationManager.js';
 import { EntityManager } from './entityManager.js';
+import { CombatManager } from './combatManager.js';
 import GuidelineLoader from './guidelineLoader.js';
 import { TooltipManager } from './tooltipManager.js';
 // DataRecorder is only needed in a Node.js environment so we lazy-load it
@@ -80,6 +81,7 @@ export {
     AIManager,
     PossessionAIManager,
     AuraManager,
+    CombatManager,
     SynergyManager,
     SpeechBubbleManager,
     SquadManager,


### PR DESCRIPTION
## Summary
- introduce new `CombatManager` class for high-level combat handling
- export `CombatManager` from managers index
- ensure `startCombat` triggers aspiration checks before combat begins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d393873ec83279090f9231cc88e9d