### PR TITLE
Fix manager handling in game.js

### DIFF
--- a/src/gameContext.js
+++ b/src/gameContext.js
@@ -14,6 +14,8 @@ class GameContext {
         this.combatManager = null;
         this.inputHandler = null;
         this.audioManager = null;
+        this.vfxManager = null;
+        this.itemManager = null;
         this.player = null;
         this.assets = null;
         this.eventManager = null;


### PR DESCRIPTION
## Summary
- consolidate manager imports in `src/game.js`
- instantiate extra managers and initialize generically
- iterate over managers for update/render cycles
- extend `GameContext` with new managers

## Testing
- `npm test` *(fails: ENOAUDIT or network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685d76ad45988327b722ce9060e4cf94