### PR TITLE
Fix crash when entities have no effects

### DIFF
--- a/src/managers/effectManager.js
+++ b/src/managers/effectManager.js
@@ -114,7 +114,7 @@ export class EffectManager {
             : Array.from(context.entityManager.entities.values());
 
         entities.forEach(entity => {
-            if (entity.effects.length === 0) return;
+            if (!entity.effects || entity.effects.length === 0) return;
 
             for (let i = entity.effects.length - 1; i >= 0; i--) {
                 const effect = entity.effects[i];


### PR DESCRIPTION
## Summary
- safeguard EffectManager from crashing if an entity does not contain an `effects` array

## Testing
- `npm test` *(fails: TensorFlow library init error, but some tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_685d98ad7b5083278e67c11c569d3148