### PR TITLE
Move skill effects to SkillManager

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -316,7 +316,8 @@ export class Game {
             this.motionManager,
             this.factory,
             this.metaAIManager,
-            this.knockbackEngine
+            this.knockbackEngine,
+            assets
         );
         this.managers.SkillManager = this.skillManager;
 
@@ -336,7 +337,14 @@ export class Game {
         }
         this.petManager = new Managers.PetManager(this.eventManager, this.factory, this.metaAIManager, this.auraManager, this.vfxManager);
         this.managers.PetManager = this.petManager;
-        this.skillManager.setManagers(this.effectManager, this.factory, this.metaAIManager, this.monsterManager);
+        this.skillManager.setManagers(
+            this.effectManager,
+            this.factory,
+            this.metaAIManager,
+            this.monsterManager,
+            this.mercenaryManager,
+            this.gameState
+        );
         this.aquariumManager = new AquariumManager(
             this.eventManager,
             this.monsterManager,
@@ -1018,176 +1026,7 @@ export class Game {
             }
         });
 
-        eventManager.subscribe('skill_used', (data) => {
-            const { caster, skill, target } = data;
-            eventManager.publish('log', { message: `${caster.constructor.name} (이)가 ${skill.name} 스킬 사용!`, color: 'aqua' });
-            this.vfxManager.castEffect(caster, skill); // 기본 시전 이펙트는 유지
-
-            const mbti = caster.properties?.mbti || '';
-            if (skill.id === SKILLS.heal.id || skill.id === SKILLS.guardian_hymn.id || skill.id === SKILLS.courage_hymn.id) {
-                if (mbti.includes('S')) this.vfxManager.addTextPopup('S', caster);
-                else if (mbti.includes('N')) this.vfxManager.addTextPopup('N', caster);
-                if (mbti.includes('E')) this.vfxManager.addTextPopup('E', caster);
-                else if (mbti.includes('I')) this.vfxManager.addTextPopup('I', caster);
-            }
-
-            // --- 스킬별 특화 이펙트 분기 ---
-
-            // 1. 힐 (Heal)
-            if (skill.id === SKILLS.heal.id) {
-                const healTarget = target || caster;
-                const amount = skill.healAmount || 10;
-                const prevHp = healTarget.hp;
-                healTarget.hp = Math.min(healTarget.maxHp, healTarget.hp + amount);
-                const healed = healTarget.hp - prevHp;
-                if (healed > 0) {
-                    eventManager.publish('log', { message: `${healTarget.constructor.name}의 체력이 ${healed} 회복되었습니다.`, color: 'lime' });
-                }
-
-                // 기존 힐 스프라이트 이펙트 유지
-                const targetCenter = { x: healTarget.x + healTarget.width / 2, y: healTarget.y + healTarget.height / 2 };
-                const healImg = assets['healing-effect'];
-                if (healImg) {
-                    this.vfxManager.addSpriteEffect(healImg, targetCenter.x, targetCenter.y, {
-                        width: healTarget.width,
-                        height: healTarget.height,
-                        blendMode: 'screen'
-                    });
-                }
-
-                // 부드럽게 피어오르는 녹색 입자와 광원 효과
-                this.vfxManager.addEmitter(targetCenter.x, targetCenter.y + healTarget.height / 2, {
-                    spawnRate: 10,
-                    duration: 30, // 0.5초간 지속
-                    particleOptions: {
-                        color: 'rgba(120, 255, 120, 0.8)',
-                        gravity: -0.05,
-                        lifespan: 90,
-                        speed: 1,
-                    }
-                });
-                this.vfxManager.addGlow(targetCenter.x, targetCenter.y, {
-                    radius: healTarget.width,
-                    colorInner: 'rgba(100, 255, 100, 0.5)',
-                    decay: 0.04
-                });
-            }
-
-            // 2. 수호의 찬가 & 용기의 찬가 (그룹 버프)
-            else if (skill.id === SKILLS.guardian_hymn.id || skill.id === SKILLS.courage_hymn.id) {
-                const isGuardian = skill.id === SKILLS.guardian_hymn.id;
-                const effectId = isGuardian ? 'shield' : 'bonus_damage';
-                const particleColor = isGuardian ? 'rgba(50, 150, 255, 0.8)' : 'rgba(255, 100, 50, 0.8)';
-                const imgKey = isGuardian ? 'guardian-hymn-effect' : 'courage-hymn-effect';
-
-                const group = this.metaAIManager.groups[caster.groupId];
-                const allies = group ? group.members : [caster];
-
-                allies.forEach(ally => {
-                    this.effectManager.addEffect(ally, effectId);
-                    const allyCenter = { x: ally.x + ally.width / 2, y: ally.y + ally.height / 2 };
-
-                    for (let i = 0; i < 4; i++) {
-                        const angle = i * Math.PI / 2;
-                        const sx = allyCenter.x + Math.cos(angle) * 100;
-                        const sy = allyCenter.y + Math.sin(angle) * 100;
-                        this.vfxManager.addHomingBurst(sx, sy, allyCenter, {
-                            count: 5,
-                            color: particleColor,
-                            particleOptions: { homingStrength: 0.08, lifespan: 40, gravity: 0 }
-                        });
-                    }
-
-                    // 기존 버프 스프라이트 효과도 함께 사용
-                    const img = assets[imgKey];
-                    if (img) {
-                        this.vfxManager.addSpriteEffect(img, allyCenter.x, allyCenter.y, {
-                            width: ally.width,
-                            height: ally.height,
-                            blendMode: 'screen',
-                            duration: 30
-                        });
-                    }
-                });
-            }
-
-            // 3. 정화 (Purify)
-            else if (skill.id === SKILLS.purify.id) {
-                const purifyTarget = target || caster;
-                const targetCenter = { x: purifyTarget.x + purifyTarget.width / 2, y: purifyTarget.y + purifyTarget.height / 2 };
-
-                this.vfxManager.addSpriteEffect(assets['purify-effect'], targetCenter.x, targetCenter.y, {
-                    width: purifyTarget.width,
-                    height: purifyTarget.height,
-                    blendMode: 'screen'
-                });
-                this.vfxManager.addParticleBurst(targetCenter.x, targetCenter.y, {
-                    color: 'rgba(50, 50, 50, 0.7)',
-                    count: 15,
-                    speed: 2,
-                    gravity: 0.01,
-                    lifespan: 60
-                });
-                this.vfxManager.addParticleBurst(targetCenter.x, targetCenter.y, {
-                    color: 'rgba(200, 200, 255, 1)',
-                    count: 10,
-                    speed: 1,
-                    gravity: -0.01,
-                    lifespan: 70
-                });
-            }
-            // 4. 파이어 노바
-            else if (skill.id === SKILLS.fire_nova.id) {
-                const centerX = caster.x + caster.width / 2;
-                const centerY = caster.y + caster.height / 2;
-                const radius = skill.effect?.radius || 192;
-
-                this.vfxManager.createNovaEffect(caster, {
-                    radius,
-                    duration: skill.vfx?.duration || 50,
-                    image: skill.vfx?.image || 'fire-nova-effect'
-                });
-
-                const enemies = caster.isFriendly ? monsterManager.monsters : [gameState.player, ...mercenaryManager.mercenaries];
-                const aoeTargets = findEntitiesInRadius(centerX, centerY, radius, enemies, caster);
-
-                aoeTargets.forEach(enemy => {
-                    eventManager.publish('entity_attack', { attacker: caster, defender: enemy, skill });
-                    if (skill.effect?.applies?.type === 'burn') {
-                        this.effectManager.addEffect(enemy, 'burn');
-                    }
-                });
-            }
-
-            // 5. 그 외 공격 스킬 (기존 로직 유지)
-            else if (skill.tags.includes('attack')) {
-                const range = skill.range || Infinity;
-                const nearestEnemy = this.findNearestEnemy(caster, monsterManager.monsters, range);
-                if (nearestEnemy) {
-                    if (skill.dashRange) {
-                        this.motionManager.dashTowards(
-                            caster,
-                            nearestEnemy,
-                            skill.dashRange,
-                            monsterManager.monsters,
-                            eventManager
-                        );
-                    }
-                    const hits = skill.hits || 1;
-                    for (let i = 0; i < hits; i++) {
-                        if (skill.projectile) {
-                            this.projectileManager.create(caster, nearestEnemy, skill);
-                        } else {
-                            eventManager.publish('entity_attack', { attacker: caster, defender: nearestEnemy, skill: skill });
-                        }
-                    }
-                } else {
-                    eventManager.publish('log', { message: '시야에 대상이 없습니다.' });
-                    caster.mp += skill.manaCost;
-                    caster.skillCooldowns[skill.id] = 0;
-                }
-            }
-        });
+        // 스킬 사용 로직은 SkillManager로 이동되었습니다.
 
         eventManager.subscribe('vfx_request', (data) => {
             if (data.type === 'dash_trail') {

--- a/src/managers/skillManager.js
+++ b/src/managers/skillManager.js
@@ -1,4 +1,5 @@
 import { SKILLS } from '../data/skills.js';
+import { findEntitiesInRadius } from '../utils/entityUtils.js';
 
 export class SkillManager {
     constructor(
@@ -8,7 +9,8 @@ export class SkillManager {
         motionManager = null,
         factory = null,
         metaAIManager = null,
-        knockbackEngine = null
+        knockbackEngine = null,
+        assets = null
     ) {
         this.eventManager = eventManager;
         this.vfxManager = vfxManager;
@@ -19,11 +21,14 @@ export class SkillManager {
         this.knockbackEngine = knockbackEngine;
         this.effectManager = null;
         this.monsterManager = null;
+        this.mercenaryManager = null;
+        this.gameState = null;
+        this.assets = assets || {};
         console.log("[SkillManager] Initialized");
 
         if (this.eventManager) {
             this.eventManager.subscribe('skill_used', ({ caster, skill, target }) => {
-                this.applySkillEffects(caster, skill, target);
+                this.onSkillUsed(caster, skill, target);
             });
         }
     }
@@ -32,11 +37,20 @@ export class SkillManager {
         this.effectManager = effectManager;
     }
 
-    setManagers(effectManager, factory, metaAIManager, monsterManager = null) {
+    setManagers(
+        effectManager,
+        factory,
+        metaAIManager,
+        monsterManager = null,
+        mercenaryManager = null,
+        gameState = null
+    ) {
         this.effectManager = effectManager;
         this.factory = factory;
         this.metaAIManager = metaAIManager;
         this.monsterManager = monsterManager;
+        this.mercenaryManager = mercenaryManager;
+        this.gameState = gameState;
     }
 
     applySkillEffects(caster, skill, target = null) {
@@ -83,6 +97,214 @@ export class SkillManager {
         if (skill.id === SKILLS.summon_skeleton.id) {
             this._handleSummon(caster);
         }
+    }
+
+    onSkillUsed(caster, skill, target = null) {
+        if (!caster || !skill) return;
+
+        this.eventManager.publish('log', {
+            message: `${caster.constructor.name} (이)가 ${skill.name} 스킬 사용!`,
+            color: 'aqua'
+        });
+
+        if (this.vfxManager) {
+            this.vfxManager.castEffect(caster, skill);
+        }
+
+        const mbti = caster.properties?.mbti || '';
+        if (
+            skill.id === SKILLS.heal.id ||
+            skill.id === SKILLS.guardian_hymn.id ||
+            skill.id === SKILLS.courage_hymn.id
+        ) {
+            if (mbti.includes('S')) this.vfxManager?.addTextPopup('S', caster);
+            else if (mbti.includes('N')) this.vfxManager?.addTextPopup('N', caster);
+            if (mbti.includes('E')) this.vfxManager?.addTextPopup('E', caster);
+            else if (mbti.includes('I')) this.vfxManager?.addTextPopup('I', caster);
+        }
+
+        // --- 스킬별 특화 이펙트 분기 ---
+        if (skill.id === SKILLS.heal.id) {
+            const healTarget = target || caster;
+            const amount = skill.healAmount || 10;
+            const prevHp = healTarget.hp;
+            healTarget.hp = Math.min(healTarget.maxHp, healTarget.hp + amount);
+            const healed = healTarget.hp - prevHp;
+            if (healed > 0) {
+                this.eventManager.publish('log', {
+                    message: `${healTarget.constructor.name}의 체력이 ${healed} 회복되었습니다.`,
+                    color: 'lime'
+                });
+            }
+
+            const targetCenter = {
+                x: healTarget.x + healTarget.width / 2,
+                y: healTarget.y + healTarget.height / 2
+            };
+            const healImg = this.assets['healing-effect'];
+            if (healImg) {
+                this.vfxManager?.addSpriteEffect(healImg, targetCenter.x, targetCenter.y, {
+                    width: healTarget.width,
+                    height: healTarget.height,
+                    blendMode: 'screen'
+                });
+            }
+            this.vfxManager?.addEmitter(targetCenter.x, targetCenter.y + healTarget.height / 2, {
+                spawnRate: 10,
+                duration: 30,
+                particleOptions: {
+                    color: 'rgba(120, 255, 120, 0.8)',
+                    gravity: -0.05,
+                    lifespan: 90,
+                    speed: 1
+                }
+            });
+            this.vfxManager?.addGlow(targetCenter.x, targetCenter.y, {
+                radius: healTarget.width,
+                colorInner: 'rgba(100, 255, 100, 0.5)',
+                decay: 0.04
+            });
+        } else if (
+            skill.id === SKILLS.guardian_hymn.id ||
+            skill.id === SKILLS.courage_hymn.id
+        ) {
+            const isGuardian = skill.id === SKILLS.guardian_hymn.id;
+            const effectId = isGuardian ? 'shield' : 'bonus_damage';
+            const particleColor = isGuardian
+                ? 'rgba(50, 150, 255, 0.8)'
+                : 'rgba(255, 100, 50, 0.8)';
+            const imgKey = isGuardian ? 'guardian-hymn-effect' : 'courage-hymn-effect';
+
+            const group = this.metaAIManager?.groups?.[caster.groupId];
+            const allies = group ? group.members : [caster];
+
+            allies.forEach(ally => {
+                this.effectManager?.addEffect(ally, effectId);
+                const allyCenter = {
+                    x: ally.x + ally.width / 2,
+                    y: ally.y + ally.height / 2
+                };
+
+                for (let i = 0; i < 4; i++) {
+                    const angle = (i * Math.PI) / 2;
+                    const sx = allyCenter.x + Math.cos(angle) * 100;
+                    const sy = allyCenter.y + Math.sin(angle) * 100;
+                    this.vfxManager?.addHomingBurst(sx, sy, allyCenter, {
+                        count: 5,
+                        color: particleColor,
+                        particleOptions: { homingStrength: 0.08, lifespan: 40, gravity: 0 }
+                    });
+                }
+
+                const img = this.assets[imgKey];
+                if (img) {
+                    this.vfxManager?.addSpriteEffect(img, allyCenter.x, allyCenter.y, {
+                        width: ally.width,
+                        height: ally.height,
+                        blendMode: 'screen',
+                        duration: 30
+                    });
+                }
+            });
+        } else if (skill.id === SKILLS.purify.id) {
+            const purifyTarget = target || caster;
+            const targetCenter = {
+                x: purifyTarget.x + purifyTarget.width / 2,
+                y: purifyTarget.y + purifyTarget.height / 2
+            };
+            const img = this.assets['purify-effect'];
+            if (img) {
+                this.vfxManager?.addSpriteEffect(img, targetCenter.x, targetCenter.y, {
+                    width: purifyTarget.width,
+                    height: purifyTarget.height,
+                    blendMode: 'screen'
+                });
+            }
+            this.vfxManager?.addParticleBurst(targetCenter.x, targetCenter.y, {
+                color: 'rgba(50, 50, 50, 0.7)',
+                count: 15,
+                speed: 2,
+                gravity: 0.01,
+                lifespan: 60
+            });
+            this.vfxManager?.addParticleBurst(targetCenter.x, targetCenter.y, {
+                color: 'rgba(200, 200, 255, 1)',
+                count: 10,
+                speed: 1,
+                gravity: -0.01,
+                lifespan: 70
+            });
+        } else if (skill.id === SKILLS.fire_nova.id) {
+            const centerX = caster.x + caster.width / 2;
+            const centerY = caster.y + caster.height / 2;
+            const radius = skill.effect?.radius || 192;
+
+            this.vfxManager?.createNovaEffect(caster, {
+                radius,
+                duration: skill.vfx?.duration || 50,
+                image: skill.vfx?.image || 'fire-nova-effect'
+            });
+
+            const enemies = caster.isFriendly
+                ? this.monsterManager?.monsters || []
+                : [this.gameState?.player, ...(this.mercenaryManager?.mercenaries || [])];
+            const aoeTargets = findEntitiesInRadius(centerX, centerY, radius, enemies, caster);
+
+            aoeTargets.forEach(enemy => {
+                this.eventManager.publish('entity_attack', { attacker: caster, defender: enemy, skill });
+                if (skill.effect?.applies?.type === 'burn') {
+                    this.effectManager?.addEffect(enemy, 'burn');
+                }
+            });
+        } else if (skill.tags.includes('attack')) {
+            const range = skill.range || Infinity;
+            const enemies = this.monsterManager?.monsters || [];
+            const nearestEnemy = this.findNearestEnemy(caster, enemies, range);
+            if (nearestEnemy) {
+                if (skill.dashRange) {
+                    this.motionManager?.dashTowards(
+                        caster,
+                        nearestEnemy,
+                        skill.dashRange,
+                        enemies,
+                        this.eventManager
+                    );
+                }
+                const hits = skill.hits || 1;
+                for (let i = 0; i < hits; i++) {
+                    if (skill.projectile) {
+                        this.projectileManager?.create(caster, nearestEnemy, skill);
+                    } else {
+                        this.eventManager.publish('entity_attack', {
+                            attacker: caster,
+                            defender: nearestEnemy,
+                            skill
+                        });
+                    }
+                }
+            } else {
+                this.eventManager.publish('log', { message: '시야에 대상이 없습니다.' });
+                caster.mp += skill.manaCost;
+                caster.skillCooldowns[skill.id] = 0;
+            }
+        }
+
+        this.applySkillEffects(caster, skill, target);
+    }
+
+    findNearestEnemy(caster, enemies, range = Infinity) {
+        let nearest = null;
+        let minDist = Infinity;
+        for (const enemy of enemies) {
+            const dx = enemy.x - caster.x;
+            const dy = enemy.y - caster.y;
+            const dist = Math.hypot(dx, dy);
+            if (dist < minDist && dist <= range) {
+                minDist = dist;
+                nearest = enemy;
+            }
+        }
+        return nearest;
     }
 
     _handleTeleport(caster) {


### PR DESCRIPTION
## Summary
- delegate skill effect logic from `game.js` to `SkillManager`
- extend `SkillManager` to handle VFX and combat for each skill
- inject assets, mercenary and player references into `SkillManager`
- update manager wiring in `game.js`

## Testing
- `npm test` *(fails: TensorFlow loader requires window; offline env)*

------
https://chatgpt.com/codex/tasks/task_e_685e0c0d611083278f3fdbe22c137698