### PR TITLE
Redistribute event responsibilities to managers

### DIFF
--- a/src/managers/itemManager.js
+++ b/src/managers/itemManager.js
@@ -1,4 +1,6 @@
 import { Item } from '../entities.js';
+import { rollOnTable } from '../utils/random.js';
+import { getMonsterLootTable } from '../data/tables.js';
 
 export class ItemManager {
     constructor(count = 0, mapManager = null, assets = null, tracker = null) {
@@ -59,5 +61,75 @@ export class ItemManager {
         for (const item of this.items) {
             item.render(ctx);
         }
+    }
+
+    /**
+     * Register event handlers for loot drops and store dependencies.
+     * This keeps Game free from item-specific logic.
+     */
+    initEvents(eventManager, itemFactory, vfxManager, entityManager) {
+        this.eventManager = eventManager;
+        this.itemFactory = itemFactory;
+        this.vfxManager = vfxManager;
+        this.entityManager = entityManager;
+        if (eventManager) {
+            eventManager.subscribe('drop_loot', data => this._handleDropLoot(data));
+        }
+    }
+
+    _handleDropLoot(data) {
+        if (!this.itemFactory || !this.mapManager) return;
+        const lootTable = getMonsterLootTable(data.monsterType);
+        const droppedId = rollOnTable(lootTable);
+        if (!droppedId) return;
+
+        const startPos = { x: data.position.x, y: data.position.y };
+        const endPos = this._findRandomEmptyAdjacentTile(startPos.x, startPos.y);
+        if (!endPos) return;
+
+        const item = this.itemFactory.create(droppedId, endPos.x, endPos.y, this.mapManager.tileSize);
+        if (!item) return;
+
+        if (this.vfxManager) {
+            this.vfxManager.addItemPopAnimation(item, startPos, endPos);
+        } else {
+            this.addItem(item);
+        }
+    }
+
+    _findRandomEmptyAdjacentTile(centerX, centerY) {
+        const tileSize = this.mapManager.tileSize || 32;
+        const baseX = Math.floor(centerX / tileSize);
+        const baseY = Math.floor(centerY / tileSize);
+        const dirs = [
+            { x: -1, y: -1 }, { x: 0, y: -1 }, { x: 1, y: -1 },
+            { x: -1, y: 0 },                   { x: 1, y: 0 },
+            { x: -1, y: 1 }, { x: 0, y: 1 }, { x: 1, y: 1 }
+        ];
+        dirs.sort(() => Math.random() - 0.5);
+
+        const entities = [];
+        if (this.entityManager) {
+            if (this.entityManager.player) entities.push(this.entityManager.player);
+            entities.push(...this.entityManager.mercenaries, ...this.entityManager.monsters);
+        }
+
+        for (const d of dirs) {
+            const tileX = baseX + d.x;
+            const tileY = baseY + d.y;
+            const worldX = tileX * tileSize;
+            const worldY = tileY * tileSize;
+            if (this.mapManager.isWallAt && this.mapManager.isWallAt(worldX, worldY)) continue;
+
+            const occupied = entities.some(e => {
+                const ex = Math.floor(e.x / tileSize);
+                const ey = Math.floor(e.y / tileSize);
+                return ex === tileX && ey === tileY;
+            });
+            if (!occupied) {
+                return { x: worldX, y: worldY };
+            }
+        }
+        return null;
     }
 }

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -67,6 +67,17 @@ export class UIManager {
         this.vfxManager = null;
         this.getSharedInventory = null;
 
+        if (this.eventManager) {
+            this.eventManager.subscribe('inventory_updated', ({ involvedEntityIds }) => {
+                this.renderSharedInventory();
+                involvedEntityIds.forEach(id => {
+                    this.updateCharacterSheet(id);
+                    const ent = this.getEntityById(id);
+                    if (ent) this.eventManager.publish('stats_changed', { entity: ent });
+                });
+            });
+        }
+
         this.draggables = [];
         this._initDraggables();
 

--- a/src/managers/vfxManager.js
+++ b/src/managers/vfxManager.js
@@ -14,6 +14,10 @@ export class VFXManager {
         this.itemManager = itemManager;
         this.knockbackEffectDuration = 15;
         console.log("[VFXManager] Initialized with Internal Engines");
+
+        if (this.eventManager) {
+            this.eventManager.subscribe('vfx_request', data => this._handleVfxRequest(data));
+        }
     }
 
     /**
@@ -332,6 +336,21 @@ export class VFXManager {
             alpha: 1.0
         };
         this.textPopupEngine.popups.push(popup);
+    }
+
+    _handleVfxRequest(data) {
+        if (!data) return;
+        if (data.type === 'dash_trail') {
+            this.createDashTrail(data.from.x, data.from.y, data.to.x, data.to.y, data.options || {});
+        } else if (data.type === 'whip_trail') {
+            if (this.createWhipTrail) {
+                this.createWhipTrail(data.from.x, data.from.y, data.to.x, data.to.y);
+            }
+        } else if (data.type === 'text_popup') {
+            this.addTextPopup(data.text, data.target, data.options || {});
+        } else if (data.type === 'knockback_animation') {
+            this.addKnockbackAnimation(data.target, data.fromPos, data.toPos);
+        }
     }
 
     addCinematicText(text, duration = 2000) {


### PR DESCRIPTION
## Summary
- move loot drop handling from `game.js` to `ItemManager`
- let `VFXManager` process `vfx_request` events
- update `UIManager` to refresh UI on `inventory_updated`
- hook `Game` into these new event APIs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e0e44ac308327a96a14a5f88be790