### PR TITLE
Reduce Aquarium map size

### DIFF
--- a/src/aquariumMap.js
+++ b/src/aquariumMap.js
@@ -6,6 +6,11 @@ import { SETTINGS } from '../config/gameSettings.js';
 export class AquariumMapManager extends MapManager {
     constructor(seed) {
         super(seed);
+        // 기본 크기를 절반으로 줄여 수족관 맵을 더 작게 만든다
+        this.width = Math.floor(this.width / 2);
+        this.height = Math.floor(this.height / 2);
+        this.rooms = [];
+
         this.name = 'aquarium';
         this.corridorWidth = 5; // widen lane width
         this.jungleWidth = 3;   // slightly thinner jungle corridors

--- a/src/game.js
+++ b/src/game.js
@@ -379,7 +379,7 @@ export class Game {
         // === 몬스터 부대 생성 ===
         const enemyFormationManager = new FormationManager(5, 5, formationSpacing, 'RIGHT', formationAngle);
         const enemyFormationOrigin = {
-            x: (this.mapManager.width - 8) * this.mapManager.tileSize,
+            x: (this.mapManager.width - 4) * this.mapManager.tileSize,
             y: (this.mapManager.height / 2) * this.mapManager.tileSize,
         };
         const monsterSquad = [];
@@ -422,7 +422,7 @@ export class Game {
 
         // === 2. 플레이어 생성 ===
         let startPos;
-        startPos = { x: this.mapManager.tileSize * 8, y: (this.mapManager.height * this.mapManager.tileSize) / 2 };
+        startPos = { x: this.mapManager.tileSize * 4, y: (this.mapManager.height * this.mapManager.tileSize) / 2 };
         const player = this.factory.create('player', {
             x: startPos.x,
             y: startPos.y,

--- a/src/managers/aquariumManager.js
+++ b/src/managers/aquariumManager.js
@@ -20,7 +20,7 @@ export class AquariumManager {
         this._roomIndex = 0;
     }
 
-    _findSpacedPosition(minDist = this.mapManager.tileSize * 4) {
+    _findSpacedPosition(minDist = this.mapManager.tileSize * 2) {
         for (let i = 0; i < 30; i++) {
             const pos = this.mapManager.getRandomFloorPosition();
             if (!pos) continue;
@@ -34,7 +34,7 @@ export class AquariumManager {
         return this.mapManager.getRandomFloorPosition();
     }
 
-    _getRoomBasedPosition(minDist = this.mapManager.tileSize * 6) {
+    _getRoomBasedPosition(minDist = this.mapManager.tileSize * 3) {
         const rooms = this.mapManager.rooms || [];
         if (rooms.length === 0) return this._findSpacedPosition(minDist);
 
@@ -58,10 +58,10 @@ export class AquariumManager {
     }
 
     spawnMonsterGroup(count = 3, opts = {}) {
-        const center = this._getRoomBasedPosition(this.mapManager.tileSize * 8);
+        const center = this._getRoomBasedPosition(this.mapManager.tileSize * 4);
         if (!center) return;
 
-        const radius = opts.radius || this.mapManager.tileSize * 2;
+        const radius = opts.radius || this.mapManager.tileSize;
         let shieldSpawned = false;
 
         for (let i = 0; i < count; i++) {
@@ -123,7 +123,7 @@ export class AquariumManager {
     addTestingFeature(feature) {
         this.features.push(feature);
         if (feature.type === 'monster') {
-            const pos = this._getRoomBasedPosition(this.mapManager.tileSize * 6);
+            const pos = this._getRoomBasedPosition(this.mapManager.tileSize * 3);
             if (pos) {
                 const vision = feature.baseStats?.visionRange ?? this.mapManager.tileSize * 2;
                 const stats = adjustMonsterStatsForAquarium({


### PR DESCRIPTION
## Summary
- make Aquarium map half the original width and height
- spawn enemies closer by halving distances from players
- update player and monster starting offsets accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e1142e9448327ba57888fb13d10d3