### PR TITLE
Implement initial GridManager with supporting engines

### DIFF
--- a/src/engines/grid/LineOfSightEngine.js
+++ b/src/engines/grid/LineOfSightEngine.js
@@ -1,0 +1,29 @@
+// src/engines/grid/LineOfSightEngine.js
+
+/**
+ * 두 지점 간의 시야(Line of Sight)를 계산하는 전문 엔진
+ */
+export class LineOfSightEngine {
+    constructor(gridManager) {
+        // 나중에 시야 계산 시 그리드 정보를 참조해야 하므로 gridManager를 받습니다.
+        this.gridManager = gridManager;
+        console.log("[LineOfSightEngine] Initialized: 시야 계산 준비 완료.");
+    }
+
+    /**
+     * 두 지점 사이에 시야가 확보되는지 확인합니다. (장애물 여부 체크)
+     * @param {{x: number, y: number}} start - 시작 타일 좌표
+     * @param {{x: number, y: number}} end - 종료 타일 좌표
+     * @returns {boolean} - 시야 확보 여부
+     */
+    hasLineOfSight(start, end) {
+        // 지금은 간단하게 항상 true를 반환하지만,
+        // 나중에는 두 지점 사이의 모든 타일을 검사하여 'wall' 같은 장애물이 있는지
+        // 확인하는 '브레젠험 알고리즘(Bresenham\'s line algorithm)' 등을 구현하게 됩니다.
+        // const tilesInBetween = this.gridManager.getTilesOnLine(start, end);
+        // for (const tile of tilesInBetween) {
+        //   if (!tile.properties.isWalkable) return false;
+        // }
+        return true;
+    }
+}

--- a/src/engines/grid/TerrainAnalysisEngine.js
+++ b/src/engines/grid/TerrainAnalysisEngine.js
@@ -1,0 +1,30 @@
+// src/engines/grid/TerrainAnalysisEngine.js
+
+/**
+ * 지형 데이터를 분석하여 속성 및 이동 비용을 계산하는 전문 엔진
+ */
+export class TerrainAnalysisEngine {
+    constructor() {
+        console.log("[TerrainAnalysisEngine] Initialized: 지형 분석 준비 완료.");
+    }
+
+    /**
+     * 특정 타일 타입의 속성을 반환합니다.
+     * @param {string} tileType - 'grass', 'water', 'wall' 등 타일의 종류
+     * @returns {{isWalkable: boolean, cost: number}} - 이동 가능 여부와 이동 비용
+     */
+    getTileProperties(tileType) {
+        switch (tileType) {
+            case 'grass':
+                return { isWalkable: true, cost: 1 };
+            case 'sand':
+                return { isWalkable: true, cost: 2 }; // 모래는 이동 비용이 더 높음
+            case 'water':
+                return { isWalkable: false, cost: Infinity };
+            case 'wall':
+                return { isWalkable: false, cost: Infinity };
+            default:
+                return { isWalkable: true, cost: 1 };
+        }
+    }
+}

--- a/src/game.js
+++ b/src/game.js
@@ -59,6 +59,7 @@ import { LaneAssignmentManager } from './managers/laneAssignmentManager.js';
 import { FormationManager } from './managers/formationManager.js';
 import { TooltipManager } from './managers/tooltipManager.js';
 import { CombatEngine } from "./engines/CombatEngine.js";
+import { GridManager } from './managers/GridManager.js';
 
 export class Game {
     constructor() {
@@ -135,6 +136,13 @@ export class Game {
         // InputHandler를 생성할 때 game 객체(this)를 전달합니다.
         this.inputHandler = new InputHandler(this);
         this.combatLogManager = new CombatLogManager(this.eventManager);
+
+        // ★★★ 교살자 나무 패턴의 첫 단계 ★★★
+        // 기존 시스템은 그대로 두는 천수에,
+        // 새로운 'GridManager'를 생성하여 추가합니다.
+        // 이 시점에서는 아직 다른 시스템이
+        // GridManager에 의존하지 않습니다.
+        this.gridManager = new GridManager(50, 30); // 50x30 크기의 그리드
         
         this.statusEffectsManager = new StatusEffectsManager(this.eventManager);
         this.tagManager = new TagManager();

--- a/src/managers/GridManager.js
+++ b/src/managers/GridManager.js
@@ -1,0 +1,67 @@
+// src/managers/GridManager.js
+import { TerrainAnalysisEngine } from '../engines/grid/TerrainAnalysisEngine.js';
+import { LineOfSightEngine } from '../engines/grid/LineOfSightEngine.js';
+
+/**
+ * 게임의 그리드 데이터를 총괄하고, 관련 엔진들을 지휘하는 매니저.
+ * 데이터의 수호자 역할을 합니다.
+ */
+export class GridManager {
+    constructor(width, height) {
+        this.width = width;
+        this.height = height;
+        this.grid = [];
+        // 1. GridManager는 자신의 '작은 엔진'들을 직접 소유하고 생성합니다.
+        this.terrainEngine = new TerrainAnalysisEngine();
+        this.sightEngine = new LineOfSightEngine(this);
+        console.log(`[GridManager] Initialized: ${width}x${height} 그리드 생성.`);
+        this._initializeGrid();
+    }
+
+    /**
+     * 그리드를 초기화하고, 각 타일의 속성을 설정합니다.
+     * @private
+     */
+    _initializeGrid() {
+        for (let y = 0; y < this.height; y++) {
+            this.grid[y] = [];
+            for (let x = 0; x < this.width; x++) {
+                const tileType = 'grass';
+                const properties = this.terrainEngine.getTileProperties(tileType);
+                this.grid[y][x] = {
+                    type: tileType,
+                    properties,
+                    unitId: null,
+                };
+            }
+        }
+    }
+
+    /**
+     * 특정 좌표의 타일 정보를 가져옵니다.
+     * @param {number} x
+     * @param {number} y
+     * @returns {object|null} 타일 데이터 또는 맵 밖일 경우 null
+     */
+    getTile(x, y) {
+        if (x >= 0 && x < this.width && y >= 0 && y < this.height) {
+            return this.grid[y][x];
+        }
+        return null;
+    }
+
+    /**
+     * 특정 좌표의 시야 확보 여부를 '질문'합니다.
+     * @param {{x: number, y: number}} start
+     * @param {{x: number, y: number}} end
+     * @returns {boolean}
+     */
+    hasClearLineOfSight(start, end) {
+        // 3. 시야 계산은 전적으로 시야 엔진에게 위임합니다.
+        return this.sightEngine.hasLineOfSight(start, end);
+    }
+
+    // 앞으로 추가될 메서드들...
+    // moveUnitTo(unitId, x, y) { ... }
+    // getUnitAt(x, y) { ... }
+}


### PR DESCRIPTION
## Summary
- add `TerrainAnalysisEngine` for tile property analysis
- add `LineOfSightEngine` for line-of-sight checks
- create `GridManager` that owns these engines and maintains grid data
- hook `GridManager` into `Game` initialization

## Testing
- `npm test` *(fails: TensorFlow loader requires window)*

------
https://chatgpt.com/codex/tasks/task_e_685e1e1b3c508327b599825fe3b1f95b