### PR TITLE
Add basic grid rendering

### DIFF
--- a/src/engines/rendering/TileRenderEngine.js
+++ b/src/engines/rendering/TileRenderEngine.js
@@ -1,0 +1,40 @@
+// src/engines/rendering/TileRenderEngine.js
+/**
+ * 기본 그리드 타일을 렌더링하는 전문 엔진
+ */
+export class TileRenderEngine {
+    constructor(context) {
+        this.ctx = context;
+        console.log("[TileRenderEngine] Initialized.");
+    }
+
+    /**
+     * GridManager로부터 받은 데이터를 기반으로 모든 타일을 그립니다.
+     * @param {GridManager} gridManager - 그리드 데이터 제공자
+     */
+    render(gridManager) {
+        const TILE_SIZE = 32; // 타일 크기 (나중에 설정으로 뺄 수 있음)
+        this.ctx.strokeStyle = '#555'; // 타일 테두리 색상
+
+        for (let y = 0; y < gridManager.height; y++) {
+            for (let x = 0; x < gridManager.width; x++) {
+                const tile = gridManager.getTile(x, y);
+                if (tile) {
+                    // 지금은 간단하게 지형 타입에 따라 색상을 칠합니다.
+                    switch (tile.type) {
+                        case 'grass':
+                            this.ctx.fillStyle = '#8BC34A';
+                            break;
+                        case 'sand':
+                            this.ctx.fillStyle = '#FFD54F';
+                            break;
+                        default:
+                            this.ctx.fillStyle = '#CCC';
+                    }
+                    this.ctx.fillRect(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+                    this.ctx.strokeRect(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+                }
+            }
+        }
+    }
+}

--- a/src/game.js
+++ b/src/game.js
@@ -60,6 +60,7 @@ import { FormationManager } from './managers/formationManager.js';
 import { TooltipManager } from './managers/tooltipManager.js';
 import { CombatEngine } from "./engines/CombatEngine.js";
 import { GridManager } from './managers/GridManager.js';
+import { GridRenderer } from './renderers/GridRenderer.js';
 
 export class Game {
     constructor() {
@@ -143,6 +144,12 @@ export class Game {
         // 이 시점에서는 아직 다른 시스템이
         // GridManager에 의존하지 않습니다.
         this.gridManager = new GridManager(50, 30); // 50x30 크기의 그리드
+
+        // Grid 시각화를 담당하는 GridRenderer를 초기화합니다.
+        this.gridRenderer = new GridRenderer(
+            this.layerManager.contexts.mapDecor,
+            this.eventManager
+        );
         
         this.statusEffectsManager = new StatusEffectsManager(this.eventManager);
         this.tagManager = new TagManager();
@@ -1237,6 +1244,8 @@ export class Game {
         if (this.gameState.currentState === "WORLD") {
             this.worldEngine.render(this.layerManager.contexts.entity);
         } else if (this.gameState.currentState === "COMBAT") {
+            // 전투 중에는 그리드 시각화 후 전투 엔진 렌더링을 진행합니다.
+            this.gridRenderer.render(this.gridManager, this.gameState.camera);
             this.combatEngine.render();
         }
         if (this.uiManager) this.uiManager.updateUI(this.gameState);

--- a/src/renderers/GridRenderer.js
+++ b/src/renderers/GridRenderer.js
@@ -1,0 +1,42 @@
+// src/renderers/GridRenderer.js
+import { TileRenderEngine } from '../engines/rendering/TileRenderEngine.js';
+// import { EffectRenderEngine } from '../engines/rendering/EffectRenderEngine.js';
+// import { DebugOverlayEngine } from '../engines/rendering/DebugOverlayEngine.js';
+
+/**
+ * 그리드와 관련된 모든 시각적 요소를 렌더링하는 매니저.
+ * 여러 렌더링 엔진을 지휘합니다.
+ */
+export class GridRenderer {
+    constructor(context, eventManager) {
+        this.ctx = context;
+        this.eventManager = eventManager;
+
+        // 렌더러가 자신의 전문 엔진들을 생성합니다.
+        this.tileRenderEngine = new TileRenderEngine(this.ctx);
+        // this.effectRenderEngine = new EffectRenderEngine(this.ctx);
+        // this.debugOverlayEngine = new DebugOverlayEngine(this.ctx);
+        
+        console.log("[GridRenderer] Initialized.");
+
+        // 예시: 그리드 데이터가 변경되었다는 이벤트를 받으면 다시 그리도록 설정
+        // this.eventManager.subscribe('grid_updated', () => this.needsRedraw = true);
+    }
+
+    /**
+     * 그리드와 관련된 모든 것을 그립니다. 게임 루프의 render 단계에서 호출됩니다.
+     * @param {GridManager} gridManager
+     * @param {Camera} camera
+     */
+    render(gridManager, camera) {
+        this.ctx.save();
+        this.ctx.translate(-camera.x, -camera.y);
+
+        // 정해진 순서대로 각 전문 엔진의 render 함수를 호출
+        this.tileRenderEngine.render(gridManager);
+        // this.effectRenderEngine.render(gridManager);
+        // this.debugOverlayEngine.render(gridManager);
+
+        this.ctx.restore();
+    }
+}


### PR DESCRIPTION
## Summary
- create `TileRenderEngine` for drawing simple grid tiles
- add `GridRenderer` that coordinates tile rendering
- initialize `GridRenderer` inside `Game` and draw grid each frame

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e21c04c2c83279fb751b0b24fb0d3