### PR TITLE
Display grid lines on world and aquarium maps

### DIFF
--- a/src/engines/rendering/TileRenderEngine.js
+++ b/src/engines/rendering/TileRenderEngine.js
@@ -3,8 +3,9 @@
  * 기본 그리드 타일을 렌더링하는 전문 엔진
  */
 export class TileRenderEngine {
-    constructor(context) {
+    constructor(context, tileSize = 32) {
         this.ctx = context;
+        this.tileSize = tileSize;
         console.log("[TileRenderEngine] Initialized.");
     }
 
@@ -13,7 +14,7 @@ export class TileRenderEngine {
      * @param {GridManager} gridManager - 그리드 데이터 제공자
      */
     render(gridManager) {
-        const TILE_SIZE = 32; // 타일 크기 (나중에 설정으로 뺄 수 있음)
+        const TILE_SIZE = this.tileSize; // 타일 크기 (나중에 설정으로 뺄 수 있음)
         this.ctx.strokeStyle = '#555'; // 타일 테두리 색상
 
         for (let y = 0; y < gridManager.height; y++) {

--- a/src/renderers/GridRenderer.js
+++ b/src/renderers/GridRenderer.js
@@ -8,12 +8,12 @@ import { TileRenderEngine } from '../engines/rendering/TileRenderEngine.js';
  * 여러 렌더링 엔진을 지휘합니다.
  */
 export class GridRenderer {
-    constructor(context, eventManager) {
+    constructor(context, eventManager, tileSize = 32) {
         this.ctx = context;
         this.eventManager = eventManager;
 
         // 렌더러가 자신의 전문 엔진들을 생성합니다.
-        this.tileRenderEngine = new TileRenderEngine(this.ctx);
+        this.tileRenderEngine = new TileRenderEngine(this.ctx, tileSize);
         // this.effectRenderEngine = new EffectRenderEngine(this.ctx);
         // this.debugOverlayEngine = new DebugOverlayEngine(this.ctx);
         
@@ -28,8 +28,9 @@ export class GridRenderer {
      * @param {GridManager} gridManager
      * @param {Camera} camera
      */
-    render(gridManager, camera) {
+    render(gridManager, camera, zoom = 1) {
         this.ctx.save();
+        this.ctx.scale(zoom, zoom);
         this.ctx.translate(-camera.x, -camera.y);
 
         // 정해진 순서대로 각 전문 엔진의 render 함수를 호출


### PR DESCRIPTION
## Summary
- parameterize grid rendering engines with tile size
- set up GridManager and GridRenderer for the aquarium map
- add a separate GridManager/GridRenderer for the world map
- render grid overlays after the maps with camera zoom applied

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e27843ccc8327bb3388c3efeddc8d