### PR TITLE
Implement Y-sorted rendering with grid placement

### DIFF
--- a/src/engines/CombatEngine.js
+++ b/src/engines/CombatEngine.js
@@ -184,21 +184,8 @@ export class CombatEngine {
         game.laneRenderManager.render(contexts.mapDecor);
         itemManager.render(contexts.mapDecor);
 
-        const allEntitiesToRender = [
-            gameState.player,
-            ...(monsterManager?.monsters || []),
-            ...(mercenaryManager?.mercenaries || []),
-            ...(game.petManager?.pets || [])
-        ].filter(e => e && !e.isDying && !e.isHidden);
-
-        allEntitiesToRender.sort((a, b) =>
-            a.y === b.y ? a.id.localeCompare(b.id) : a.y - b.y
-        );
-
         const entityCtx = contexts.entity;
-        for (const entity of allEntitiesToRender) {
-            entity.render(entityCtx);
-        }
+        game.entityManager.renderSorted(entityCtx);
 
         if (fogManager) {
             fogManager.render(contexts.vfx, mapManager.tileSize);

--- a/src/entities.js
+++ b/src/entities.js
@@ -90,6 +90,13 @@ class Entity {
         };
     }
 
+    /**
+     * Bottom center position of the entity used for rendering and sorting.
+     */
+    get pos() {
+        return { x: this.x + this.width / 2, y: this.y + this.height };
+    }
+
     get speed() { return this.stats.get('movementSpeed'); }
     get attackPower() {
         return this.stats.get('attackPower') + (this.damageBonus || 0);
@@ -139,7 +146,8 @@ class Entity {
 
         ctx.save();
         // 캔버스 원점을 유닛의 발 중앙으로 이동
-        ctx.translate(this.x + this.width / 2, this.y + this.height);
+        const { x: baseX, y: baseY } = this.pos;
+        ctx.translate(baseX, baseY);
 
         // 1. 그림자 먼저 그리기 (yOffset의 영향을 받지 않음)
         ctx.fillStyle = 'rgba(0, 0, 0, 0.4)';
@@ -504,3 +512,6 @@ export class Ghost {
         this.state = 'seeking'; // 'seeking', 'possessing', 'wandering'
     }
 }
+
+// Export base Entity for generic usage
+export { Entity };

--- a/src/game.js
+++ b/src/game.js
@@ -31,7 +31,7 @@ import { SupportEngine } from './systems/SupportEngine.js';
 import { SKILLS } from './data/skills.js';
 import { EFFECTS } from './data/effects.js';
 import { ITEMS } from './data/items.js';
-import { Item } from './entities.js';
+import { Item, Entity } from './entities.js';
 import { rollOnTable } from './utils/random.js';
 import { getMonsterLootTable } from './data/tables.js';
 import { MicroEngine } from './micro/MicroEngine.js';
@@ -151,12 +151,34 @@ export class Game {
         this.laneRenderManager = new LaneRenderManager(this.laneManager, SETTINGS.ENABLE_AQUARIUM_LANES);
 
         // 전투 맵 크기에 맞춘 그리드 매니저와 렌더러를 초기화합니다.
-        this.gridManager = new GridManager(this.mapManager.width, this.mapManager.height);
+        this.gridManager = new GridManager(
+            this.mapManager.width,
+            this.mapManager.height,
+            this.mapManager.tileSize
+        );
         this.gridRenderer = new GridRenderer(
             this.layerManager.contexts.mapDecor,
             this.eventManager,
             this.mapManager.tileSize
         );
+
+        // --- Temporary test units placed on the grid for Y-sorting demo ---
+        const unit1 = new Entity({
+            x: 0,
+            y: 0,
+            tileSize: this.mapManager.tileSize,
+            image: assets.player,
+        });
+        const unit2 = new Entity({
+            x: 0,
+            y: 0,
+            tileSize: this.mapManager.tileSize,
+            image: assets.player,
+        });
+        this.entityManager.addEntity(unit1);
+        this.entityManager.addEntity(unit2);
+        this.gridManager.placeUnit(unit1, 5, 4);
+        this.gridManager.placeUnit(unit2, 5, 5);
 
         const formationSpacing = this.mapManager.tileSize * 2.5;
         const formationAngle = -Math.PI / 4; // align grid with battlefield orientation
@@ -185,7 +207,11 @@ export class Game {
         this.worldEngine = new WorldEngine(this, assets);
         const worldGridW = this.worldEngine.worldWidth / this.worldEngine.tileSize;
         const worldGridH = this.worldEngine.worldHeight / this.worldEngine.tileSize;
-        this.worldGridManager = new GridManager(worldGridW, worldGridH);
+        this.worldGridManager = new GridManager(
+            worldGridW,
+            worldGridH,
+            this.worldEngine.tileSize
+        );
         this.worldGridRenderer = new GridRenderer(
             this.layerManager.contexts.entity,
             this.eventManager,

--- a/src/managers/GridManager.js
+++ b/src/managers/GridManager.js
@@ -2,14 +2,18 @@
 import { TerrainAnalysisEngine } from '../engines/grid/TerrainAnalysisEngine.js';
 import { LineOfSightEngine } from '../engines/grid/LineOfSightEngine.js';
 
+// 기본 타일 크기. 별도의 값이 주어지지 않으면 이 크기를 사용한다.
+export const TILE_SIZE = 32;
+
 /**
  * 게임의 그리드 데이터를 총괄하고, 관련 엔진들을 지휘하는 매니저.
  * 데이터의 수호자 역할을 합니다.
  */
 export class GridManager {
-    constructor(width, height) {
+    constructor(width, height, tileSize = TILE_SIZE) {
         this.width = width;
         this.height = height;
+        this.tileSize = tileSize;
         this.grid = [];
         // 1. GridManager는 자신의 '작은 엔진'들을 직접 소유하고 생성합니다.
         this.terrainEngine = new TerrainAnalysisEngine();
@@ -59,6 +63,26 @@ export class GridManager {
     hasClearLineOfSight(start, end) {
         // 3. 시야 계산은 전적으로 시야 엔진에게 위임합니다.
         return this.sightEngine.hasLineOfSight(start, end);
+    }
+
+    /**
+     * Place a unit on the given grid coordinates. The unit's position is
+     * adjusted so that its feet align with the bottom-center of the tile.
+     *
+     * @param {Entity} unit
+     * @param {number} x
+     * @param {number} y
+     */
+    placeUnit(unit, x, y) {
+        const tile = this.getTile(x, y);
+        if (tile && !tile.unitId) {
+            tile.unitId = unit.id;
+            unit.x = (x * this.tileSize) + (this.tileSize / 2) - (unit.width / 2);
+            unit.y = (y * this.tileSize) + this.tileSize - unit.height;
+            console.log(`[GridManager] ${unit.id}를 (${x}, ${y})에 배치했습니다.`);
+        } else {
+            console.error(`[GridManager] (${x}, ${y})에 유닛을 배치할 수 없습니다.`);
+        }
     }
 
     // 앞으로 추가될 메서드들...

--- a/src/managers/entityManager.js
+++ b/src/managers/entityManager.js
@@ -51,4 +51,32 @@ export class EntityManager {
     getMonsters() {
         return this.monsters;
     }
+
+    /**
+     * Render all tracked entities using Y-sorting. Entities with a lower
+     * bottom position are drawn first so that taller units naturally overlap
+     * those in front.
+     *
+     * @param {CanvasRenderingContext2D} ctx
+     * @param {{x:number,y:number}=} camera - if provided, translation is applied
+     */
+    renderSorted(ctx, camera = null) {
+        const all = Array.from(this.entities.values()).filter(e => e && !e.isDying && !e.isHidden);
+        all.sort((a, b) => {
+            const ay = (a.y + (a.height || 0));
+            const by = (b.y + (b.height || 0));
+            return ay === by ? a.id.localeCompare(b.id) : ay - by;
+        });
+
+        if (camera) {
+            ctx.save();
+            ctx.translate(-camera.x, -camera.y);
+        }
+
+        for (const ent of all) {
+            if (ent.render) ent.render(ctx);
+        }
+
+        if (camera) ctx.restore();
+    }
 }


### PR DESCRIPTION
## Summary
- add `renderSorted` to `EntityManager` for unified Y-sorted drawing
- expose bottom center position via new `Entity.pos`
- allow grid managers to place units on tiles and track tile size
- initialize `GridManager` with tile size and place demo units
- use the new rendering in `CombatEngine`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e2c1c273c8327b8910a12fb664e37