### PR TITLE
Add combat turn sequencing engines

### DIFF
--- a/docs-managers-summary.md
+++ b/docs-managers-summary.md
@@ -62,10 +62,13 @@
 | `tagManager.js` | 아이템과 스킬에 부여된 태그를 조회해 AI나 다른 시스템에 전달합니다. |
 | `traitManager.js` | 유닛의 특성 부여와 스탯 변화를 관리합니다. |
 | `turnManager.js` | 턴 기반 전투 모드에서 행동 순서를 결정하도록 설계되었습니다. |
+| `CombatTurnEngine.js` | 전투 라운드의 턴 흐름을 관리하는 상위 엔진입니다. |
 | `uiManager.js` | 인벤토리와 용병 패널 등 DOM 기반 UI 요소를 관리합니다. |
 | `vfxManager.js` | 파티클 및 스프라이트 효과를 생성하여 시각 연출을 담당합니다. |
 | `vfx/ParticleEngine.js` | 파티클과 이미터 생성을 전담하는 내부 엔진입니다. |
 | `vfx/TextPopupEngine.js` | 데미지 수치 등 부유하는 텍스트 팝업을 관리합니다. |
+| `engines/turn/TurnSequencingEngine.js` | 무게 스탯을 바탕으로 행동 순서를 계산합니다. |
+| `engines/turn/ActionExecutionEngine.js` | 결정된 행동을 애니메이션과 사운드로 연출합니다. |
 | `../systems/KnockbackEngine.js` | 공격 피격 시 대상에게 밀쳐내기 효과와 시각 연출을 적용합니다. |
 | `../micro/MicroEngine.js` | 미시 세계 전투와 아이템 상태 갱신을 담당하는 엔진입니다. |
 | `../micro/MicroTurnManager.js` | 모든 아이템의 쿨타임 감소를 전담합니다. |

--- a/src/engines/turn/ActionExecutionEngine.js
+++ b/src/engines/turn/ActionExecutionEngine.js
@@ -1,0 +1,39 @@
+// src/engines/turn/ActionExecutionEngine.js
+
+/**
+ * 결정된 행동(공격, 스킬)을 받아 애니메이션, VFX, 사운드 등
+ * 실제 연출을 순차적으로 실행하는 전문 엔진
+ */
+export class ActionExecutionEngine {
+    constructor(animationManager, vfxManager, soundManager) {
+        this.animationManager = animationManager;
+        this.vfxManager = vfxManager;
+        this.soundManager = soundManager;
+        console.log("[ActionExecutionEngine] Initialized.");
+    }
+
+    /**
+     * AI로부터 받은 액션 플랜을 실행합니다.
+     * @param {object} actionPlan - { actorId, actionType, skillId, targetId }
+     * @returns {Promise<void>} - 모든 연출이 끝나면 resolve되는 Promise
+     */
+    async execute(actionPlan) {
+        console.log(`[ActionExecutionEngine] Executing:`, actionPlan);
+
+        // 1. 애니메이션 재생 (예: 공격 모션)
+        // await this.animationManager.play(actionPlan.actorId, 'attack');
+
+        // 2. 사운드 재생
+        // this.soundManager.play('sword_swing');
+
+        // 3. 이펙트(VFX) 출력
+        // this.vfxManager.createEffect('slash', actionPlan.targetId);
+
+        // 모든 연출이 끝난 후, 실제 데미지 계산은 CombatCalculator에 위임
+        // 이 때 eventManager.publish('action_completed', { plan: actionPlan }); 를 호출하여
+        // CombatCalculator가 데미지를 계산하도록 할 수 있습니다.
+
+        // 지금은 연출이 즉시 끝난다고 가정
+        return Promise.resolve();
+    }
+}

--- a/src/engines/turn/TurnSequencingEngine.js
+++ b/src/engines/turn/TurnSequencingEngine.js
@@ -1,0 +1,32 @@
+// src/engines/turn/TurnSequencingEngine.js
+
+/**
+ * 유닛들의 '무게' 스탯을 기반으로 전투의 행동 순서를 결정하는 전문 엔진
+ */
+export class TurnSequencingEngine {
+    constructor() {
+        console.log("[TurnSequencingEngine] Initialized.");
+    }
+
+    /**
+     * 모든 유닛의 무게를 계산하여 해당 라운드의 행동 순서 리스트를 반환합니다.
+     * @param {Array<Unit>} allUnits - 전투에 참여하는 모든 유닛(지휘관)의 배열
+     * @returns {Array<string>} - 유닛 ID가 순서대로 정렬된 배열
+     */
+    calculateTurnOrder(allUnits) {
+        // 유닛의 장비 무게, 기본 스탯 등을 종합하여 '행동 속도'를 계산
+        const unitsWithSpeed = allUnits.map(unit => {
+            // 지금은 무게만 보지만, 나중엔 민첩성 등 다른 스탯도 반영 가능
+            const totalWeight = unit.equipment.getTotalWeight();
+            // 속도는 무게에 반비례한다고 가정
+            const speed = 1000 - totalWeight;
+            return { unitId: unit.id, speed: speed };
+        });
+
+        // 속도가 높은 순(내림차순)으로 정렬
+        unitsWithSpeed.sort((a, b) => b.speed - a.speed);
+
+        console.log("[TurnSequencingEngine] Turn order calculated:", unitsWithSpeed.map(u => u.unitId));
+        return unitsWithSpeed.map(u => u.unitId);
+    }
+}

--- a/src/managers/CombatTurnEngine.js
+++ b/src/managers/CombatTurnEngine.js
@@ -1,0 +1,67 @@
+// src/managers/CombatTurnEngine.js
+import { TurnSequencingEngine } from '../engines/turn/TurnSequencingEngine.js';
+import { ActionExecutionEngine } from '../engines/turn/ActionExecutionEngine.js';
+
+/**
+ * 전투 시 턴의 흐름을 관리하는 엔진.
+ * TurnManager가 '전투' 국면에서 사용할 전략입니다.
+ */
+export class CombatTurnEngine {
+    constructor(eventManager, turnWorker) {
+        this.eventManager = eventManager;
+        this.turnWorker = turnWorker; // AI 계산을 요청할 워커
+        this.units = []; // 전투 참여 유닛 목록
+        this.turnOrder = []; // 이번 라운드의 턴 순서
+        this.currentTurnIndex = 0;
+
+        // 전문 엔진들을 생성
+        this.sequencingEngine = new TurnSequencingEngine();
+        // this.executionEngine = new ActionExecutionEngine(...);
+
+        console.log("[CombatTurnEngine] Initialized.");
+    }
+
+    /**
+     * 전투를 시작합니다.
+     * @param {Array<Unit>} units - 아군과 적군 유닛 배열
+     */
+    startCombat(units) {
+        this.units = units;
+        console.log("[CombatTurnEngine] Combat started.");
+
+        // 1. [용맹] 스탯에 따라 모든 유닛의 보호막을 계산하고 적용합니다.
+        // this.units.forEach(unit => unit.applyValorShield());
+
+        // 2. [무게]를 기반으로 첫 라운드의 턴 순서를 결정합니다.
+        this.turnOrder = this.sequencingEngine.calculateTurnOrder(this.units);
+
+        // 3. 첫 턴을 시작합니다.
+        this.startNextTurn();
+    }
+
+    /**
+     * 다음 유닛의 턴을 시작합니다.
+     */
+    async startNextTurn() {
+        if (this.currentTurnIndex >= this.turnOrder.length) {
+            // 모든 유닛이 행동했다면 라운드 종료
+            console.log("[CombatTurnEngine] Round ended.");
+            // 다음 라운드 준비...
+            return;
+        }
+
+        const currentUnitId = this.turnOrder[this.currentTurnIndex];
+        const currentUnit = this.units.find(u => u.id === currentUnitId);
+        console.log(`[CombatTurnEngine] It's ${currentUnit.name}'s turn.`);
+
+        // AI Worker에게 행동 결정을 요청합니다.
+        // const actionPlan = await this.turnWorker.decideAction(currentUnit, this.units);
+
+        // Worker로부터 받은 행동 계획을 실행 엔진에게 넘겨 연출합니다.
+        // await this.executionEngine.execute(actionPlan);
+
+        // 턴 종료
+        this.currentTurnIndex++;
+        this.startNextTurn();
+    }
+}


### PR DESCRIPTION
## Summary
- add `TurnSequencingEngine` for weight-based turn order
- add `ActionExecutionEngine` skeleton for playing actions
- add `CombatTurnEngine` manager that coordinates combat turns
- document the new turn engines in `docs-managers-summary.md`

## Testing
- `npm test` *(fails: ReferenceError window is not defined / missing images)*

------
https://chatgpt.com/codex/tasks/task_e_685e2e12b8488327a29180af784dde56