### PR TITLE
Add fallback guidelines

### DIFF
--- a/config/gameSettings.js
+++ b/config/gameSettings.js
@@ -31,6 +31,8 @@ export const SETTINGS = {
     // Remote markdown guidelines are fetched via the GitHub API.
     // Specify the path in 'owner/repo/contents/<folder>?ref=branch' format.
     GUIDELINE_REPO_URL: "cagecorn/doom-crawler-newest/contents/TensorFlow%27s%20room?ref=main",
+    // Local fallback markdown file when remote fetch fails
+    DEFAULT_GUIDELINE_FILE: "TensorFlow's room/guideline.md",
     // 이동 속도는 StatManager의 'movement' 스탯으로부터 파생됩니다.
     // ... 나중에 더 많은 설정 추가
 };

--- a/src/managers/guidelineLoader.js
+++ b/src/managers/guidelineLoader.js
@@ -2,8 +2,10 @@
 import { SETTINGS } from '../../config/gameSettings.js';
 
 export default class GuidelineLoader {
-    constructor(url = SETTINGS.GUIDELINE_REPO_URL) {
+    constructor(url = SETTINGS.GUIDELINE_REPO_URL, fallbackFile = SETTINGS.DEFAULT_GUIDELINE_FILE, fetchFn = (typeof fetch !== 'undefined' ? fetch : null)) {
         this.url = url;
+        this.fallbackFile = fallbackFile;
+        this.fetch = fetchFn;
         this.guidelines = {};
     }
 
@@ -13,21 +15,31 @@ export default class GuidelineLoader {
             return [];
         }
         const apiUrl = `https://api.github.com/repos/${this.url}`;
-        const res = await fetch(apiUrl);
-        if (!res.ok) {
-            console.warn('[GuidelineLoader] Failed to fetch list:', res.status);
+        try {
+            const res = await this.fetch(apiUrl);
+            if (!res.ok) {
+                console.warn('[GuidelineLoader] Failed to fetch list:', res.status);
+                return [];
+            }
+            const files = await res.json();
+            return files.filter(f => f.name && f.name.endsWith('.md'));
+        } catch (e) {
+            console.warn('[GuidelineLoader] Error fetching list', e);
             return [];
         }
-        const files = await res.json();
-        return files.filter(f => f.name && f.name.endsWith('.md'));
     }
 
     async load() {
         const list = await this.fetchMarkdownList();
         const guidelines = {};
+        if (list.length === 0 && this.fallbackFile) {
+            const fallback = await this.loadFallback();
+            this.guidelines = fallback;
+            return fallback;
+        }
         for (const file of list) {
             try {
-                const res = await fetch(file.download_url);
+                const res = await this.fetch(file.download_url);
                 if (!res.ok) {
                     console.warn('[GuidelineLoader] Failed to fetch', file.name);
                     continue;
@@ -42,6 +54,25 @@ export default class GuidelineLoader {
         this.guidelines = guidelines;
         console.log(`[GuidelineLoader] Loaded ${Object.keys(guidelines).length} guidelines`);
         return guidelines;
+    }
+
+    async loadFallback() {
+        try {
+            const res = await this.fetch(this.fallbackFile);
+            if (!res.ok) {
+                console.warn('[GuidelineLoader] Failed to fetch fallback', this.fallbackFile, res.status);
+                return {};
+            }
+            const text = await res.text();
+            const key = this.fallbackFile.split('/').pop().replace(/\.md$/, '');
+            const data = {};
+            data[key] = this.parseMarkdown(text);
+            console.log('[GuidelineLoader] Loaded fallback guideline');
+            return data;
+        } catch (e) {
+            console.warn('[GuidelineLoader] Error loading fallback', e);
+            return {};
+        }
     }
 
     parseMarkdown(md) {


### PR DESCRIPTION
## Summary
- allow GuidelineLoader to load a local markdown file when remote fetching fails
- expose DEFAULT_GUIDELINE_FILE in `SETTINGS`
- pass a custom fetch function to GuidelineLoader tests to avoid global fetch
- test fallback behavior

## Testing
- `npm test` *(fails: TensorFlow loader error)*
- `node tests/unit/guidelineLoader.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685e2f9520288327bb6ad3f27c169ace