### PR TITLE
Add combat turn engine and integrate into aquarium test battle

### DIFF
--- a/src/engines/turn/TurnSequencingEngine.js
+++ b/src/engines/turn/TurnSequencingEngine.js
@@ -5,28 +5,35 @@
  */
 export class TurnSequencingEngine {
     constructor() {
-        console.log("[TurnSequencingEngine] Initialized.");
+        console.log("[TurnSequencingEngine] Initialized: 턴 순서 결정 준비 완료.");
     }
 
     /**
-     * 모든 유닛의 무게를 계산하여 해당 라운드의 행동 순서 리스트를 반환합니다.
-     * @param {Array<Unit>} allUnits - 전투에 참여하는 모든 유닛(지휘관)의 배열
+     * 유닛들의 무게를 계산하여 해당 라운드의 행동 순서 리스트를 반환합니다.
+     * @param {Array<Object>} allUnits - 전투에 참여하는 모든 유닛(지휘관)의 배열
      * @returns {Array<string>} - 유닛 ID가 순서대로 정렬된 배열
      */
     calculateTurnOrder(allUnits) {
-        // 유닛의 장비 무게, 기본 스탯 등을 종합하여 '행동 속도'를 계산
+        console.log("[TurnSequencingEngine] 턴 순서 계산 시작...");
+
         const unitsWithSpeed = allUnits.map(unit => {
-            // 지금은 무게만 보지만, 나중엔 민첩성 등 다른 스탯도 반영 가능
-            const totalWeight = unit.equipment.getTotalWeight();
-            // 속도는 무게에 반비례한다고 가정
-            const speed = 1000 - totalWeight;
+            // 지금은 임시로 무게 값을 0~100 사이 랜덤으로 가정합니다.
+            // 나중에 실제 장비 시스템이 구현되면 unit.equipment.getTotalWeight() 등으로 대체됩니다.
+            const totalWeight = unit.weight || Math.floor(Math.random() * 101);
+
+            // 속도는 무게에 반비례한다고 가정 (단순 모델)
+            // 나중에 민첩(Agility) 등 다른 스탯도 여기에 반영할 수 있습니다.
+            const speed = 1000 - totalWeight + (unit.agility || 0);
+
+            console.log(`- ${unit.id}: 무게 ${totalWeight}, 속도 ${speed}`);
             return { unitId: unit.id, speed: speed };
         });
 
         // 속도가 높은 순(내림차순)으로 정렬
         unitsWithSpeed.sort((a, b) => b.speed - a.speed);
 
-        console.log("[TurnSequencingEngine] Turn order calculated:", unitsWithSpeed.map(u => u.unitId));
-        return unitsWithSpeed.map(u => u.unitId);
+        const turnOrder = unitsWithSpeed.map(u => u.unitId);
+        console.log("[TurnSequencingEngine] 턴 순서 계산 완료:", turnOrder);
+        return turnOrder;
     }
 }

--- a/src/game.js
+++ b/src/game.js
@@ -61,6 +61,7 @@ import { TooltipManager } from './managers/tooltipManager.js';
 import { CombatEngine } from "./engines/CombatEngine.js";
 import { GridManager } from './managers/GridManager.js';
 import { GridRenderer } from './renderers/GridRenderer.js';
+import { CombatTurnEngine } from './managers/CombatTurnEngine.js';
 
 export class Game {
     constructor() {
@@ -162,23 +163,22 @@ export class Game {
             this.mapManager.tileSize
         );
 
-        // --- Temporary test units placed on the grid for Y-sorting demo ---
-        const unit1 = new Entity({
-            x: 0,
-            y: 0,
-            tileSize: this.mapManager.tileSize,
-            image: assets.player,
-        });
-        const unit2 = new Entity({
-            x: 0,
-            y: 0,
-            tileSize: this.mapManager.tileSize,
-            image: assets.player,
-        });
+        // ★★★ 새로운 CombatTurnEngine을 생성합니다. ★★★
+        // 아직 AI 워커가 없으므로 eventManager만 넘겨줍니다.
+        this.combatTurnEngine = new CombatTurnEngine(this.eventManager);
+
+        // ★★★ 테스트용 유닛 데이터 수정 ★★★
+        const unit1 = new Entity({ id: 'Hero_LightArmor', weight: 20, x: 0, y: 0, tileSize: this.mapManager.tileSize, image: assets.player });
+        const unit2 = new Entity({ id: 'Hero_HeavyArmor', weight: 80, x: 0, y: 0, tileSize: this.mapManager.tileSize, image: assets.player });
+        const monster1 = new Entity({ id: 'Goblin', weight: 30, x: 0, y: 0, tileSize: this.mapManager.tileSize, image: assets.monster });
         this.entityManager.addEntity(unit1);
         this.entityManager.addEntity(unit2);
+        this.entityManager.addEntity(monster1);
+
+        // 그리드에 배치 (렌더링을 위해)
         this.gridManager.placeUnit(unit1, 5, 4);
-        this.gridManager.placeUnit(unit2, 5, 5);
+        this.gridManager.placeUnit(unit2, 6, 4);
+        this.gridManager.placeUnit(monster1, 5, 8);
 
         const formationSpacing = this.mapManager.tileSize * 2.5;
         const formationAngle = -Math.PI / 4; // align grid with battlefield orientation
@@ -835,6 +835,10 @@ export class Game {
 
         this.gameLoop = new GameLoop(this.update, this.render);
         this.gameLoop.start();
+
+        // ★★★ 게임 시작과 동시에 전투를 개시합니다. ★★★
+        // EntityManager로부터 모든 유닛 목록을 가져와 전투를 시작합니다.
+        this.combatTurnEngine.startCombat(this.entityManager.getAllEntities());
     }
 
     setupEventListeners(assets, canvas) {

--- a/src/managers/entityManager.js
+++ b/src/managers/entityManager.js
@@ -52,6 +52,11 @@ export class EntityManager {
         return this.monsters;
     }
 
+    // 현재 관리 중인 모든 엔티티 객체를 배열로 반환합니다.
+    getAllEntities() {
+        return Array.from(this.entities.values());
+    }
+
     /**
      * Render all tracked entities using Y-sorting. Entities with a lower
      * bottom position are drawn first so that taller units naturally overlap


### PR DESCRIPTION
## Summary
- implement a simple TurnSequencingEngine that sorts units by weight
- overhaul CombatTurnEngine to handle rounds and basic turn flow
- expose EntityManager.getAllEntities helper
- hook CombatTurnEngine in `game.js` with test units on the aquarium map

## Testing
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e38ab9cf88327aa18d5af57ad88cd