### PR TITLE
Introduce AI worker for combat turns

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -163,14 +163,23 @@ export class Game {
             this.mapManager.tileSize
         );
 
-        // ★★★ 새로운 CombatTurnEngine을 생성합니다. ★★★
-        // 아직 AI 워커가 없으므로 eventManager만 넘겨줍니다.
-        this.combatTurnEngine = new CombatTurnEngine(this.eventManager);
+        // ★★★ Web Worker를 생성합니다. ★★★
+        const turnWorker = new Worker('./src/workers/turn.worker.js', { type: 'module' });
 
-        // ★★★ 테스트용 유닛 데이터 수정 ★★★
-        const unit1 = new Entity({ id: 'Hero_LightArmor', weight: 20, x: 0, y: 0, tileSize: this.mapManager.tileSize, image: assets.player });
-        const unit2 = new Entity({ id: 'Hero_HeavyArmor', weight: 80, x: 0, y: 0, tileSize: this.mapManager.tileSize, image: assets.player });
+        // CombatTurnEngine에 워커를 주입합니다.
+        this.combatTurnEngine = new CombatTurnEngine(this.eventManager, turnWorker);
+
+        // ★★★ 테스트 유닛에 팀과 스킬 정보를 추가합니다. ★★★
+        const unit1 = new Entity({ id: 'Hero_Light', weight: 20, x: 0, y: 0, tileSize: this.mapManager.tileSize, image: assets.player });
+        const unit2 = new Entity({ id: 'Hero_Heavy', weight: 80, x: 0, y: 0, tileSize: this.mapManager.tileSize, image: assets.player });
         const monster1 = new Entity({ id: 'Goblin', weight: 30, x: 0, y: 0, tileSize: this.mapManager.tileSize, image: assets.monster });
+
+        unit1.team = 'player';
+        unit2.team = 'player';
+        monster1.team = 'enemy';
+        unit1.skills = [{ id: 'quick_slash' }];
+        unit2.skills = [{ id: 'heavy_smash' }];
+        monster1.skills = [{ id: 'bite' }];
         this.entityManager.addEntity(unit1);
         this.entityManager.addEntity(unit2);
         this.entityManager.addEntity(monster1);

--- a/src/workers/ai/TargetingEngine.js
+++ b/src/workers/ai/TargetingEngine.js
@@ -1,0 +1,34 @@
+// src/workers/ai/TargetingEngine.js
+
+/**
+ * 행동의 대상을 결정하는 전문 엔진 (Worker 내부에서 사용)
+ */
+export class TargetingEngine {
+    constructor() {}
+
+    /**
+     * 가장 합리적인 공격 대상을 찾습니다.
+     * @param {object} actor - 행동을 취하는 유닛
+     * @param {Array<object>} allUnits - 모든 유닛의 정보
+     * @returns {string|null} - 대상 유닛의 ID
+     */
+    findBestTarget(actor, allUnits) {
+        // 지금은 가장 간단한 로직: 가장 가까운 적을 찾습니다.
+        // actor와 다른 진영(team)에 속한 유닛만 필터링합니다.
+        const enemies = allUnits.filter(u => u.team !== actor.team);
+        if (enemies.length === 0) return null;
+
+        let closestEnemy = null;
+        let minDistance = Infinity;
+
+        // 맨해튼 거리 계산으로 가장 가까운 적을 찾습니다.
+        for (const enemy of enemies) {
+            const distance = Math.abs(actor.pos.x - enemy.pos.x) + Math.abs(actor.pos.y - enemy.pos.y);
+            if (distance < minDistance) {
+                minDistance = distance;
+                closestEnemy = enemy;
+            }
+        }
+        return closestEnemy.id;
+    }
+}

--- a/src/workers/ai/UtilityAI_Engine.js
+++ b/src/workers/ai/UtilityAI_Engine.js
@@ -1,0 +1,37 @@
+// src/workers/ai/UtilityAI_Engine.js
+import { TargetingEngine } from './TargetingEngine.js';
+
+/**
+ * 여러 엔진의 분석을 종합하여 최적의 행동을 결정하는 AI의 총괄 두뇌 (Worker 내부)
+ */
+export class UtilityAI_Engine {
+    constructor() {
+        this.targetingEngine = new TargetingEngine();
+    }
+
+    /**
+     * 현재 상황에서 가장 가치 있는 행동 계획을 수립합니다.
+     * @param {object} actor - 행동 주체
+     * @param {Array<object>} allUnits - 모든 유닛 정보
+     * @returns {object} - 최종 행동 계획 (Action Plan)
+     */
+    decideAction(actor, allUnits) {
+        // 1. [확률 기반 스킬 사용 결정] (지금은 간단하게 50% 확률로 스킬 또는 공격 결정)
+        const useSkill = Math.random() < 0.5;
+
+        // 2. [타겟 결정]
+        const targetId = this.targetingEngine.findBestTarget(actor, allUnits);
+        if (!targetId) {
+            return { actorId: actor.id, type: 'IDLE' }; // 할 게 없으면 대기
+        }
+
+        // 3. [최종 행동 계획 수립]
+        if (useSkill && actor.skills && actor.skills.length > 0) {
+            // 지금은 첫 번째 스킬을 사용한다고 가정
+            const skillId = actor.skills[0].id;
+            return { actorId: actor.id, type: 'SKILL', skillId: skillId, targetId: targetId };
+        } else {
+            return { actorId: actor.id, type: 'ATTACK', targetId: targetId };
+        }
+    }
+}

--- a/src/workers/turn.worker.js
+++ b/src/workers/turn.worker.js
@@ -1,0 +1,20 @@
+// src/workers/turn.worker.js
+import { UtilityAI_Engine } from './ai/UtilityAI_Engine.js';
+
+console.log("[TurnWorker] 워커 스크립트 로드됨.");
+const aiEngine = new UtilityAI_Engine();
+
+// 메인 스레드로부터 메시지를 받았을 때 실행될 함수
+self.onmessage = (event) => {
+    console.log("[TurnWorker] 메인 스레드로부터 메시지 수신:", event.data);
+
+    const { actor, allUnits } = event.data;
+
+    // AI 엔진을 통해 행동을 결정합니다. (가장 계산이 오래 걸리는 부분)
+    const actionPlan = aiEngine.decideAction(actor, allUnits);
+
+    console.log("[TurnWorker] 행동 계획 수립 완료, 메인 스레드로 전송:", actionPlan);
+
+    // 결정된 행동 계획을 메인 스레드로 다시 보냅니다.
+    self.postMessage(actionPlan);
+};


### PR DESCRIPTION
## Summary
- implement AI-focused worker system
- add `TargetingEngine` and `UtilityAI_Engine` for decision making
- create `turn.worker.js` to run the AI engines in a Web Worker
- refactor `CombatTurnEngine` to request decisions from the worker
- initialize the worker in `Game` and set up sample units with teams and skills

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e3b7779ac8327819f72c3b9a7831b