### PR TITLE
Add combat calculator and damage flow

### DIFF
--- a/src/engines/turn/ActionExecutionEngine.js
+++ b/src/engines/turn/ActionExecutionEngine.js
@@ -5,7 +5,8 @@
  * 실제 연출을 순차적으로 실행하는 전문 엔진
  */
 export class ActionExecutionEngine {
-    constructor(vfxManager, soundManager) {
+    constructor(eventManager, vfxManager, soundManager) {
+        this.eventManager = eventManager;
         this.vfxManager = vfxManager;
         this.soundManager = soundManager;
         // 나중에는 애니메이션 매니저도 여기에 추가됩니다.
@@ -52,7 +53,10 @@ export class ActionExecutionEngine {
 
             await this.wait(500); // 연출이 끝난 후 잠시 대기
             console.log('%c[연출 종료]', 'color: #F44336; font-weight: bold;');
-            
+
+            // ★★★ 연출 종료 후 결과 계산을 지시하는 이벤트 발행 ★★★
+            this.eventManager.publish('execute_action_effect', { actionPlan, unitMap });
+
             // 모든 연출이 끝나면 Promise를 완료시켜 다음 턴으로 넘어갈 수 있음을 알림
             resolve();
         });

--- a/src/entities.js
+++ b/src/entities.js
@@ -238,6 +238,7 @@ class Entity {
         }
         this.hp -= damage;
         if (this.hp < 0) this.hp = 0;
+        console.log(`[Entity] ${this.id}가 ${damage}의 피해를 입음. 현재 HP: ${this.hp}`);
     }
 }
 

--- a/src/game.js
+++ b/src/game.js
@@ -6,7 +6,7 @@ import { InputHandler } from './inputHandler.js';
 import { CharacterFactory, ItemFactory } from './factory.js';
 import { EventManager } from './managers/eventManager.js';
 import { CombatLogManager, SystemLogManager } from './managers/logManager.js';
-import { CombatCalculator } from './combat.js';
+import { CombatCalculator } from './managers/CombatCalculator.js';
 import { TagManager } from './managers/tagManager.js';
 import { WorldEngine } from './worldEngine.js';
 import { MapManager } from './map.js';
@@ -151,7 +151,7 @@ export class Game {
         
         this.statusEffectsManager = new StatusEffectsManager(this.eventManager);
         this.tagManager = new TagManager();
-        this.combatCalculator = new CombatCalculator(this.eventManager, this.tagManager);
+        this.combatCalculator = new CombatCalculator(this.eventManager);
         // Player begins in the Aquarium map for feature testing
         this.mapManager = new AquariumMapManager();
         const mapPixelWidth = this.mapManager.width * this.mapManager.tileSize;

--- a/src/managers/CombatCalculator.js
+++ b/src/managers/CombatCalculator.js
@@ -1,0 +1,56 @@
+// src/managers/CombatCalculator.js
+
+/**
+ * 행동의 결과를 받아 실제 데미지, 힐 등을 계산하고 적용하는 전문가
+ */
+export class CombatCalculator {
+    constructor(eventManager) {
+        this.eventManager = eventManager;
+
+        // 'execute_action_effect' 이벤트를 구독하여 계산을 수행하도록 설정
+        this.eventManager.subscribe('execute_action_effect', (data) => this.handleAction(data));
+        
+        console.log('[CombatCalculator] Initialized: 전투 계산 준비 완료.');
+    }
+
+    /**
+     * 행동 계획에 따라 실제 효과를 계산하고 적용합니다.
+     * @param {object} data - { actionPlan, unitMap }
+     */
+    handleAction({ actionPlan, unitMap }) {
+        const actor = unitMap.get(actionPlan.actorId);
+        const target = unitMap.get(actionPlan.targetId);
+
+        if (!actor || !target) return;
+
+        let damage = 0;
+        switch (actionPlan.type) {
+            case 'ATTACK':
+                // 지금은 단순하게 공격자의 'attack' 스탯을 기본 데미지로 사용합니다.
+                damage = actor.stats.attack || actor.attackPower || 10;
+                console.log(`[CombatCalculator] ${actor.id}가 ${target.id}에게 기본 공격! 기본 피해량: ${damage}`);
+                break;
+            case 'SKILL':
+                // 스킬의 기본 데미지 + 공격자의 스탯 등을 조합하여 계산합니다.
+                damage = (actionPlan.skill?.basePower || 0) + (actor.stats.magic || actor.stats.focus || 0);
+                console.log(`[CombatCalculator] ${actor.id}가 ${target.id}에게 스킬 사용! 스킬 피해량: ${damage}`);
+                break;
+        }
+
+        if (damage > 0) {
+            // 실제 데미지를 입히고, 그 결과를 다른 시스템에 방송합니다.
+            if (typeof target.takeDamage === 'function') {
+                target.takeDamage(damage);
+            } else {
+                target.hp -= damage;
+                if (target.hp < 0) target.hp = 0;
+            }
+
+            this.eventManager.publish('unit_damaged', {
+                targetId: target.id,
+                damage,
+                newHp: target.hp
+            });
+        }
+    }
+}

--- a/src/managers/CombatTurnEngine.js
+++ b/src/managers/CombatTurnEngine.js
@@ -18,7 +18,7 @@ export class CombatTurnEngine {
 
         this.sequencingEngine = new TurnSequencingEngine();
         // ★★★ 행동 실행 엔진을 생성하고 주입받은 매니저들을 넘겨줍니다. ★★★
-        this.executionEngine = new ActionExecutionEngine(vfxManager, soundManager);
+        this.executionEngine = new ActionExecutionEngine(eventManager, vfxManager, soundManager);
 
         // 워커로부터 수신한 행동 계획을 처리합니다.
         this.worker.onmessage = (event) => {


### PR DESCRIPTION
## Summary
- add CombatCalculator manager for turn-based damage calculation
- hook ActionExecutionEngine to publish `execute_action_effect`
- route CombatTurnEngine and Game to use CombatCalculator
- log damage in `Entity.takeDamage`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e41d7b99483279a84c279b971770d