### PR TITLE
Apply turn engine on aquarium map

### DIFF
--- a/config/gameSettings.js
+++ b/config/gameSettings.js
@@ -26,6 +26,9 @@ export const SETTINGS = {
     // Aquarium map uses a 3-lane layout with jungle maze by default.
     // Set this to false to revert to a standard dungeon layout.
     ENABLE_AQUARIUM_LANES: false,
+    // Turn-based combat engine toggle. When true, CombatTurnEngine
+    // handles unit turns instead of the real-time CombatEngine.
+    ENABLE_TURN_BASED_COMBAT: false,
     // guideline markdown files will be loaded from this GitHub API path
     // example: 'user/repo/contents/guidelines?ref=main'
     // Remote markdown guidelines are fetched via the GitHub API.

--- a/src/aquariumMap.js
+++ b/src/aquariumMap.js
@@ -6,6 +6,8 @@ import { SETTINGS } from '../config/gameSettings.js';
 export class AquariumMapManager extends MapManager {
     constructor(seed) {
         super(seed);
+        // Turn-based maps use a smaller tile size for grid-based combat.
+        this.tileSize = 32;
         // 기본 크기를 절반으로 줄여 수족관 맵을 더 작게 만든다
         this.width = Math.floor(this.width / 2);
         this.height = Math.floor(this.height / 2);

--- a/src/game.js
+++ b/src/game.js
@@ -157,6 +157,8 @@ export class Game {
         this.combatCalculator = new CombatCalculator(this.eventManager);
         // Player begins in the Aquarium map for feature testing
         this.mapManager = new AquariumMapManager();
+        // If using the Aquarium map, enable the experimental turn-based mode.
+        this.turnBasedMode = SETTINGS.ENABLE_TURN_BASED_COMBAT || this.mapManager.name === 'aquarium';
         const mapPixelWidth = this.mapManager.width * this.mapManager.tileSize;
         const mapPixelHeight = this.mapManager.height * this.mapManager.tileSize;
         const laneCenters = this.mapManager.getLaneCenters ? this.mapManager.getLaneCenters() : null;
@@ -1285,6 +1287,11 @@ export class Game {
     }
 
     update = (deltaTime) => {
+        if (this.turnBasedMode) {
+            // Turn-based engine runs independently once combat starts.
+            this.vfxManager.update();
+            return;
+        }
         if (this.gameState.currentState === 'WORLD') {
             this.worldEngine.update();
             return;
@@ -1298,7 +1305,13 @@ export class Game {
     }
     render = () => {
         this.layerManager.clear();
-        if (this.gameState.currentState === "WORLD") {
+        if (this.turnBasedMode) {
+            this.gridRenderer.render(
+                this.gridManager,
+                this.gameState.camera,
+                this.gameState.zoomLevel || 1
+            );
+        } else if (this.gameState.currentState === "WORLD") {
             this.worldEngine.render(this.layerManager.contexts.entity);
             this.worldGridRenderer.render(
                 this.worldGridManager,


### PR DESCRIPTION
## Summary
- enable turn-based combat toggle in `gameSettings`
- shrink aquarium map tile size for grid-based combat
- start turn-based mode automatically on the aquarium map
- skip real-time combat update when turn mode is active and render using the grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e4ba770e483279f0bb30bb119241b