### PR TITLE
Fix target selection null handling and worker async postMessage

### DIFF
--- a/src/workers/ai/TargetingEngine.js
+++ b/src/workers/ai/TargetingEngine.js
@@ -24,11 +24,13 @@ export class TargetingEngine {
         // 맨해튼 거리 계산으로 가장 가까운 적을 찾습니다.
         for (const enemy of enemies) {
             const distance = Math.abs(actor.pos.x - enemy.pos.x) + Math.abs(actor.pos.y - enemy.pos.y);
-            if (distance < minDistance) {
+            if (Number.isFinite(distance) && distance < minDistance) {
                 minDistance = distance;
                 closestEnemy = enemy;
             }
         }
-        return closestEnemy.id;
+
+        // 유효한 대상을 찾지 못하면 null을 반환합니다.
+        return closestEnemy ? closestEnemy.id : null;
     }
 }

--- a/src/workers/turn.worker.js
+++ b/src/workers/turn.worker.js
@@ -5,13 +5,13 @@ console.log("[TurnWorker] 워커 스크립트 로드됨.");
 const aiEngine = new UtilityAI_Engine();
 
 // 메인 스레드로부터 메시지를 받았을 때 실행될 함수
-self.onmessage = (event) => {
+self.onmessage = async (event) => {
     console.log("[TurnWorker] 메인 스레드로부터 메시지 수신:", event.data);
 
     const { actor, allUnits } = event.data;
 
     // AI 엔진을 통해 행동을 결정합니다. (가장 계산이 오래 걸리는 부분)
-    const actionPlan = aiEngine.decideAction(actor, allUnits);
+    const actionPlan = await aiEngine.decideAction(actor, allUnits);
 
     console.log("[TurnWorker] 행동 계획 수립 완료, 메인 스레드로 전송:", actionPlan);
 


### PR DESCRIPTION
## Summary
- handle invalid distances in `TargetingEngine.findBestTarget`
- wait for `UtilityAI_Engine.decideAction` in `turn.worker.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e4e7531848327905294f9706ae7d8