### PR TITLE
Fix targeting null handling and add unit tests

### DIFF
--- a/src/workers/ai/TargetingEngine.js
+++ b/src/workers/ai/TargetingEngine.js
@@ -16,6 +16,7 @@ export class TargetingEngine {
         // 지금은 가장 간단한 로직: 가장 가까운 적을 찾습니다.
         // actor와 다른 진영(team)에 속한 유닛만 필터링합니다.
         const enemies = allUnits.filter(u => u.team !== actor.team);
+        // 적이 없을 경우 null을 반환하여 호출 측이 안전하게 처리하도록 합니다.
         if (enemies.length === 0) return null;
 
         let closestEnemy = null;

--- a/src/workers/turn.worker.js
+++ b/src/workers/turn.worker.js
@@ -5,6 +5,8 @@ console.log("[TurnWorker] 워커 스크립트 로드됨.");
 const aiEngine = new UtilityAI_Engine();
 
 // 메인 스레드로부터 메시지를 받았을 때 실행될 함수
+// 과거에는 aiEngine.decideAction의 반환 Promise를 그대로 postMessage 하면서
+// DataCloneError가 발생했다. async 핸들러로 바꿔 결과 값을 기다린 후 전송한다.
 self.onmessage = async (event) => {
     console.log("[TurnWorker] 메인 스레드로부터 메시지 수신:", event.data);
 

--- a/tests/unit/targetingEngine.test.js
+++ b/tests/unit/targetingEngine.test.js
@@ -1,0 +1,22 @@
+import { describe, test, assert } from '../helpers.js';
+import { TargetingEngine } from '../../src/workers/ai/TargetingEngine.js';
+
+describe('TargetingEngine', () => {
+    test('returns null when no enemies', () => {
+        const engine = new TargetingEngine();
+        const actor = { team: 1, pos: { x: 0, y: 0 } };
+        const allUnits = [actor];
+        const result = engine.findBestTarget(actor, allUnits);
+        assert.strictEqual(result, null);
+    });
+
+    test('returns closest enemy id', () => {
+        const engine = new TargetingEngine();
+        const actor = { id: 'a', team: 1, pos: { x: 0, y: 0 } };
+        const enemy1 = { id: 'e1', team: 2, pos: { x: 5, y: 0 } };
+        const enemy2 = { id: 'e2', team: 2, pos: { x: 2, y: 0 } };
+        const allUnits = [actor, enemy1, enemy2];
+        const result = engine.findBestTarget(actor, allUnits);
+        assert.strictEqual(result, 'e2');
+    });
+});


### PR DESCRIPTION
## Summary
- clarify null return logic in `TargetingEngine`
- document why the worker awaits action plans before posting
- add a unit test verifying `TargetingEngine` null handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e50163bf483278cc0204f523f0c50