### PR TITLE
Fix turn-based sprite rendering

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -1306,6 +1306,8 @@ export class Game {
     render = () => {
         this.layerManager.clear();
         if (this.turnBasedMode) {
+            const ctxEntity = this.layerManager.contexts.entity;
+            this.entityManager.renderSorted(ctxEntity, this.gameState.camera);
             this.gridRenderer.render(
                 this.gridManager,
                 this.gameState.camera,


### PR DESCRIPTION
## Summary
- render entities on the entity canvas while turn-based combat is active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e5324c4108327afe06c58cba2f53a