### PR TITLE
Enable Game rendering during turn animations

### DIFF
--- a/src/engines/turn/ActionExecutionEngine.js
+++ b/src/engines/turn/ActionExecutionEngine.js
@@ -3,7 +3,8 @@
 const TILE_SIZE = 32; // GridManager와 동일한 타일 크기
 
 export class ActionExecutionEngine {
-    constructor(eventManager, vfxManager, soundManager) {
+    constructor(game, eventManager, vfxManager, soundManager) {
+        this.game = game;
         this.eventManager = eventManager;
         this.vfxManager = vfxManager;
         this.soundManager = soundManager;
@@ -57,6 +58,7 @@ export class ActionExecutionEngine {
     }
 
     animateMovement(objectToMove, targetPos, duration) {
+        const game = this.game;
         return new Promise(resolve => {
             const startPos = { ...objectToMove.pos };
             const startTime = performance.now();
@@ -67,6 +69,10 @@ export class ActionExecutionEngine {
 
                 objectToMove.pos.x = startPos.x + (targetPos.x - startPos.x) * progress;
                 objectToMove.pos.y = startPos.y + (targetPos.y - startPos.y) * progress;
+
+                if (game && typeof game.render === 'function') {
+                    game.render();
+                }
 
                 if (progress < 1) {
                     requestAnimationFrame(tick);

--- a/src/game.js
+++ b/src/game.js
@@ -181,7 +181,7 @@ export class Game {
         const turnWorker = new Worker('./src/workers/turn.worker.js', { type: 'module' });
 
         // ★★★ CombatTurnEngine에 모든 의존성을 주입합니다. ★★★
-        this.combatTurnEngine = new CombatTurnEngine(this.eventManager, turnWorker, vfxManager, soundManager);
+        this.combatTurnEngine = new CombatTurnEngine(this, this.eventManager, turnWorker, vfxManager, soundManager);
 
         // ★★★ 테스트 유닛에 팀과 스킬 정보를 추가합니다. ★★★
         const managers = {

--- a/src/managers/CombatTurnEngine.js
+++ b/src/managers/CombatTurnEngine.js
@@ -7,7 +7,8 @@ import { ActionExecutionEngine } from '../engines/turn/ActionExecutionEngine.js'
  * TurnManager가 '전투' 국면에서 사용할 전략입니다.
  */
 export class CombatTurnEngine {
-    constructor(eventManager, worker, vfxManager, soundManager) {
+    constructor(game, eventManager, worker, vfxManager, soundManager) {
+        this.game = game;
         this.eventManager = eventManager;
         this.worker = worker;
         this.unitMap = new Map(); // ID로 유닛을 빠르게 찾기 위한 Map
@@ -18,7 +19,7 @@ export class CombatTurnEngine {
 
         this.sequencingEngine = new TurnSequencingEngine();
         // ★★★ 행동 실행 엔진을 생성하고 주입받은 매니저들을 넘겨줍니다. ★★★
-        this.executionEngine = new ActionExecutionEngine(eventManager, vfxManager, soundManager);
+        this.executionEngine = new ActionExecutionEngine(this.game, eventManager, vfxManager, soundManager);
 
         // 워커로부터 수신한 행동 계획을 처리합니다.
         this.worker.onmessage = (event) => {


### PR DESCRIPTION
## Summary
- send `game` reference into `CombatTurnEngine`
- propagate `game` reference into `ActionExecutionEngine`
- call `game.render()` from movement animation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e563e7e548327bf73cfce9886510f