### PR TITLE
Introduce skeletal grid architecture

### DIFF
--- a/src/managers/gridManager.js
+++ b/src/managers/gridManager.js
@@ -1,0 +1,63 @@
+// src/managers/gridManager.js
+// Turn-based Grid Manager skeleton inspired by ARCHITECTURE_ROADMAP.md
+
+export class TerrainAnalysisEngine {
+    constructor(mapManager) {
+        this.mapManager = mapManager;
+    }
+
+    getTileType(x, y) {
+        if (y < 0 || y >= this.mapManager.height) return null;
+        if (x < 0 || x >= this.mapManager.width) return null;
+        return this.mapManager.map[y][x];
+    }
+
+    getMoveCost(x, y) {
+        const type = this.getTileType(x, y);
+        if (type === this.mapManager.tileTypes.WALL) return Infinity;
+        return 1;
+    }
+}
+
+export class LineOfSightEngine {
+    constructor(mapManager) {
+        this.mapManager = mapManager;
+    }
+
+    hasLineOfSight(sx, sy, ex, ey) {
+        let x0 = sx, y0 = sy;
+        let x1 = ex, y1 = ey;
+        const dx = Math.abs(x1 - x0);
+        const dy = Math.abs(y1 - y0);
+        const sxStep = x0 < x1 ? 1 : -1;
+        const syStep = y0 < y1 ? 1 : -1;
+        let err = dx - dy;
+
+        while (true) {
+            if (this.mapManager.map[y0]?.[x0] === this.mapManager.tileTypes.WALL) {
+                return false;
+            }
+            if (x0 === x1 && y0 === y1) break;
+            const e2 = 2 * err;
+            if (e2 > -dy) { err -= dy; x0 += sxStep; }
+            if (e2 < dx) { err += dx; y0 += syStep; }
+        }
+        return true;
+    }
+}
+
+export class GridManager {
+    constructor(mapManager) {
+        this.mapManager = mapManager;
+        this.terrainEngine = new TerrainAnalysisEngine(mapManager);
+        this.lineEngine = new LineOfSightEngine(mapManager);
+    }
+
+    isWalkable(x, y) {
+        return this.terrainEngine.getMoveCost(x, y) < Infinity;
+    }
+
+    lineOfSight(sx, sy, ex, ey) {
+        return this.lineEngine.hasLineOfSight(sx, sy, ex, ey);
+    }
+}

--- a/src/renderers/gridRenderer.js
+++ b/src/renderers/gridRenderer.js
@@ -1,0 +1,31 @@
+// src/renderers/gridRenderer.js
+// Minimal GridRenderer using Canvas2D. This will later be replaced by WebGPU.
+
+export class GridRenderer {
+    constructor(canvas, tileSize = 32) {
+        this.canvas = canvas;
+        this.ctx = canvas.getContext('2d');
+        this.tileSize = tileSize;
+    }
+
+    render(gridManager) {
+        const { map, tileTypes } = gridManager.mapManager;
+        this.canvas.width = map[0].length * this.tileSize;
+        this.canvas.height = map.length * this.tileSize;
+        for (let y = 0; y < map.length; y++) {
+            for (let x = 0; x < map[y].length; x++) {
+                const tile = map[y][x];
+                switch (tile) {
+                    case tileTypes.WALL:
+                        this.ctx.fillStyle = '#222';
+                        break;
+                    case tileTypes.FLOOR:
+                    default:
+                        this.ctx.fillStyle = '#666';
+                        break;
+                }
+                this.ctx.fillRect(x * this.tileSize, y * this.tileSize, this.tileSize, this.tileSize);
+            }
+        }
+    }
+}

--- a/src/workers/turnWorker.js
+++ b/src/workers/turnWorker.js
@@ -1,0 +1,13 @@
+importScripts('../managers/turnManager.js');
+
+let manager = null;
+
+onmessage = (e) => {
+  const { type } = e.data;
+  if (type === 'init') {
+    manager = new TurnManager();
+  } else if (type === 'step' && manager) {
+    manager.update([], {});
+    postMessage({ turn: manager.turnCount });
+  }
+};

--- a/tests/unit/gridManager.test.js
+++ b/tests/unit/gridManager.test.js
@@ -1,0 +1,40 @@
+import { GridManager } from '../../src/managers/gridManager.js';
+import { describe, test, assert } from '../helpers.js';
+
+describe('Managers', () => {
+  test('isWalkable returns false on walls', () => {
+    const mapManager = {
+      map: [[0,1]],
+      width: 2,
+      height: 1,
+      tileSize: 1,
+      tileTypes: { FLOOR:0, WALL:1 }
+    };
+    const gm = new GridManager(mapManager);
+    assert.strictEqual(gm.isWalkable(1,0), false);
+  });
+
+  test('lineOfSight passes when clear', () => {
+    const mm = {
+      map: [ [0,0], [0,0] ],
+      width: 2,
+      height: 2,
+      tileSize: 1,
+      tileTypes: { FLOOR:0, WALL:1 }
+    };
+    const gm = new GridManager(mm);
+    assert.ok(gm.lineOfSight(0,0,1,1));
+  });
+
+  test('lineOfSight blocked by wall', () => {
+    const mm = {
+      map: [ [0,1], [0,0] ],
+      width: 2,
+      height: 2,
+      tileSize: 1,
+      tileTypes: { FLOOR:0, WALL:1 }
+    };
+    const gm = new GridManager(mm);
+    assert.strictEqual(gm.lineOfSight(0,0,1,0), false);
+  });
+});


### PR DESCRIPTION
## Summary
- begin new grid-based architecture based on ARCHITECTURE_ROADMAP
- add `GridManager` with terrain and line-of-sight engines
- add simple canvas `GridRenderer`
- provide a `TurnWorker` to step the `TurnManager`
- test grid manager functionality

## Testing
- `node tests/unit/gridManager.test.js`
- `npm test` *(fails: Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_685e61dca6b08327918375e807c5a072