### PR TITLE
Introduce grid layer in game UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
     </div>
     <div id="canvas-container">
         <canvas id="map-base-canvas" class="game-layer"></canvas>
+        <canvas id="grid-canvas" class="game-layer"></canvas>
         <canvas id="map-decor-canvas" class="game-layer"></canvas>
         <canvas id="ground-fx-canvas" class="game-layer"></canvas>
         <canvas id="entity-canvas" class="game-layer"></canvas>

--- a/src/game.js
+++ b/src/game.js
@@ -12,6 +12,8 @@ import { WorldEngine } from './worldEngine.js';
 import { MapManager } from './map.js';
 import { AquariumMapManager } from './aquariumMap.js';
 import { AquariumManager, AquariumInspector } from './managers/aquariumManager.js';
+import { GridManager } from './managers/gridManager.js';
+import { GridRenderer } from './renderers/gridRenderer.js';
 import * as Managers from './managers/index.js'; // managers/index.js에서 모든 매니저를 한 번에 불러옴
 import { ReputationManager } from './managers/ReputationManager.js';
 import { AssetLoader } from './assetLoader.js';
@@ -141,6 +143,9 @@ export class Game {
         this.combatCalculator = new CombatCalculator(this.eventManager, this.tagManager);
         // Player begins in the Aquarium map for feature testing
         this.mapManager = new AquariumMapManager();
+        this.gridManager = new GridManager(this.mapManager);
+        this.gridRenderer = new GridRenderer(document.getElementById('grid-canvas'), this.mapManager.tileSize);
+        this.gridRenderer.render(this.gridManager);
         const mapPixelWidth = this.mapManager.width * this.mapManager.tileSize;
         const mapPixelHeight = this.mapManager.height * this.mapManager.tileSize;
         const laneCenters = this.mapManager.getLaneCenters ? this.mapManager.getLaneCenters() : null;

--- a/src/managers/gridManager.js
+++ b/src/managers/gridManager.js
@@ -1,0 +1,63 @@
+// src/managers/gridManager.js
+// Turn-based Grid Manager skeleton inspired by ARCHITECTURE_ROADMAP.md
+
+export class TerrainAnalysisEngine {
+    constructor(mapManager) {
+        this.mapManager = mapManager;
+    }
+
+    getTileType(x, y) {
+        if (y < 0 || y >= this.mapManager.height) return null;
+        if (x < 0 || x >= this.mapManager.width) return null;
+        return this.mapManager.map[y][x];
+    }
+
+    getMoveCost(x, y) {
+        const type = this.getTileType(x, y);
+        if (type === this.mapManager.tileTypes.WALL) return Infinity;
+        return 1;
+    }
+}
+
+export class LineOfSightEngine {
+    constructor(mapManager) {
+        this.mapManager = mapManager;
+    }
+
+    hasLineOfSight(sx, sy, ex, ey) {
+        let x0 = sx, y0 = sy;
+        let x1 = ex, y1 = ey;
+        const dx = Math.abs(x1 - x0);
+        const dy = Math.abs(y1 - y0);
+        const sxStep = x0 < x1 ? 1 : -1;
+        const syStep = y0 < y1 ? 1 : -1;
+        let err = dx - dy;
+
+        while (true) {
+            if (this.mapManager.map[y0]?.[x0] === this.mapManager.tileTypes.WALL) {
+                return false;
+            }
+            if (x0 === x1 && y0 === y1) break;
+            const e2 = 2 * err;
+            if (e2 > -dy) { err -= dy; x0 += sxStep; }
+            if (e2 < dx) { err += dx; y0 += syStep; }
+        }
+        return true;
+    }
+}
+
+export class GridManager {
+    constructor(mapManager) {
+        this.mapManager = mapManager;
+        this.terrainEngine = new TerrainAnalysisEngine(mapManager);
+        this.lineEngine = new LineOfSightEngine(mapManager);
+    }
+
+    isWalkable(x, y) {
+        return this.terrainEngine.getMoveCost(x, y) < Infinity;
+    }
+
+    lineOfSight(sx, sy, ex, ey) {
+        return this.lineEngine.hasLineOfSight(sx, sy, ex, ey);
+    }
+}

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -18,6 +18,7 @@ import { MovementManager } from './movementManager.js';
 import { LaneManager } from './laneManager.js';
 import { LaneRenderManager } from './laneRenderManager.js';
 import { EquipmentRenderManager } from './equipmentRenderManager.js';
+import { GridManager } from './gridManager.js';
 import { ParticleDecoratorManager } from './particleDecoratorManager.js';
 import { TraitManager } from './traitManager.js';
 import { ParasiteManager } from './parasiteManager.js';
@@ -68,6 +69,7 @@ export {
     LaneManager,
     LaneRenderManager,
     EquipmentRenderManager,
+    GridManager,
     ParticleDecoratorManager,
     TraitManager,
     ParasiteManager,

--- a/src/managers/layerManager.js
+++ b/src/managers/layerManager.js
@@ -4,6 +4,7 @@ export class LayerManager {
     constructor(useWebGL = false) {
         this.layers = {
             mapBase: document.getElementById('map-base-canvas'),
+            grid: document.getElementById('grid-canvas'),
             mapDecor: document.getElementById('map-decor-canvas'),
             groundFx: document.getElementById('ground-fx-canvas'),
             entity: document.getElementById('entity-canvas'),

--- a/src/renderers/gridRenderer.js
+++ b/src/renderers/gridRenderer.js
@@ -1,0 +1,31 @@
+// src/renderers/gridRenderer.js
+// Minimal GridRenderer using Canvas2D. This will later be replaced by WebGPU.
+
+export class GridRenderer {
+    constructor(canvas, tileSize = 32) {
+        this.canvas = canvas;
+        this.ctx = canvas.getContext('2d');
+        this.tileSize = tileSize;
+    }
+
+    render(gridManager) {
+        const { map, tileTypes } = gridManager.mapManager;
+        this.canvas.width = map[0].length * this.tileSize;
+        this.canvas.height = map.length * this.tileSize;
+        for (let y = 0; y < map.length; y++) {
+            for (let x = 0; x < map[y].length; x++) {
+                const tile = map[y][x];
+                switch (tile) {
+                    case tileTypes.WALL:
+                        this.ctx.fillStyle = '#222';
+                        break;
+                    case tileTypes.FLOOR:
+                    default:
+                        this.ctx.fillStyle = '#666';
+                        break;
+                }
+                this.ctx.fillRect(x * this.tileSize, y * this.tileSize, this.tileSize, this.tileSize);
+            }
+        }
+    }
+}

--- a/src/workers/turnWorker.js
+++ b/src/workers/turnWorker.js
@@ -1,0 +1,13 @@
+importScripts('../managers/turnManager.js');
+
+let manager = null;
+
+onmessage = (e) => {
+  const { type } = e.data;
+  if (type === 'init') {
+    manager = new TurnManager();
+  } else if (type === 'step' && manager) {
+    manager.update([], {});
+    postMessage({ turn: manager.turnCount });
+  }
+};

--- a/style.css
+++ b/style.css
@@ -29,6 +29,7 @@ body, html {
     image-rendering: crisp-edges;
 }
 #map-base-canvas    { z-index: 10; }
+#grid-canvas        { z-index: 15; }
 #map-decor-canvas   { z-index: 20; }
 #ground-fx-canvas   { z-index: 30; }
 #entity-canvas      { z-index: 40; }

--- a/tests/unit/gridManager.test.js
+++ b/tests/unit/gridManager.test.js
@@ -1,0 +1,40 @@
+import { GridManager } from '../../src/managers/gridManager.js';
+import { describe, test, assert } from '../helpers.js';
+
+describe('Managers', () => {
+  test('isWalkable returns false on walls', () => {
+    const mapManager = {
+      map: [[0,1]],
+      width: 2,
+      height: 1,
+      tileSize: 1,
+      tileTypes: { FLOOR:0, WALL:1 }
+    };
+    const gm = new GridManager(mapManager);
+    assert.strictEqual(gm.isWalkable(1,0), false);
+  });
+
+  test('lineOfSight passes when clear', () => {
+    const mm = {
+      map: [ [0,0], [0,0] ],
+      width: 2,
+      height: 2,
+      tileSize: 1,
+      tileTypes: { FLOOR:0, WALL:1 }
+    };
+    const gm = new GridManager(mm);
+    assert.ok(gm.lineOfSight(0,0,1,1));
+  });
+
+  test('lineOfSight blocked by wall', () => {
+    const mm = {
+      map: [ [0,1], [0,0] ],
+      width: 2,
+      height: 2,
+      tileSize: 1,
+      tileTypes: { FLOOR:0, WALL:1 }
+    };
+    const gm = new GridManager(mm);
+    assert.strictEqual(gm.lineOfSight(0,0,1,0), false);
+  });
+});


### PR DESCRIPTION
## Summary
- export `GridManager` and insert grid canvas layer
- integrate `GridRenderer` in `Game` initialization
- support new layer in `LayerManager`

## Testing
- `node run-tests.mjs`
- `node tests/unit/gridManager.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685e61dca6b08327918375e807c5a072