### PR TITLE
Integrate grid renderer

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -59,6 +59,7 @@ import { LaneAssignmentManager } from './managers/laneAssignmentManager.js';
 import { FormationManager } from './managers/formationManager.js';
 import { TooltipManager } from './managers/tooltipManager.js';
 import { CombatEngine } from "./engines/CombatEngine.js";
+import { GridRenderer } from './renderers/gridRenderer.js';
 
 export class Game {
     constructor() {
@@ -172,6 +173,14 @@ export class Game {
         // 월드맵 로직을 담당하는 엔진
         this.worldEngine = new WorldEngine(this, assets);
         this.combatEngine = new CombatEngine(this);
+
+        // --- GridRenderer 인스턴스 생성 ---
+        // AquariumMapManager의 정보를 바탕으로 GridRenderer를 초기화합니다.
+        this.gridRenderer = new GridRenderer({
+            mapWidth: this.mapManager.width * this.mapManager.tileSize,
+            mapHeight: this.mapManager.height * this.mapManager.tileSize,
+            tileSize: this.mapManager.tileSize
+        });
 
         // --- 매니저 생성 부분 수정 ---
         this.managers = {};
@@ -1228,8 +1237,26 @@ export class Game {
         this.layerManager.clear();
         if (this.gameState.currentState === "WORLD") {
             this.worldEngine.render(this.layerManager.contexts.entity);
+            // 월드맵에 그리드 렌더링 추가
+            if (this.worldEngine.gridRenderer) {
+                const worldCtx = this.layerManager.contexts.mapDecor;
+                worldCtx.save();
+                worldCtx.scale(this.gameState.zoomLevel, this.gameState.zoomLevel);
+                worldCtx.translate(-this.worldEngine.camera.x, -this.worldEngine.camera.y);
+                this.worldEngine.gridRenderer.render(worldCtx);
+                worldCtx.restore();
+            }
         } else if (this.gameState.currentState === "COMBAT") {
             this.combatEngine.render();
+            // 전투 맵에 그리드 렌더링 추가
+            if (this.gridRenderer) {
+                const combatCtx = this.layerManager.contexts.mapDecor;
+                combatCtx.save();
+                combatCtx.scale(this.gameState.zoomLevel, this.gameState.zoomLevel);
+                combatCtx.translate(-this.gameState.camera.x, -this.gameState.camera.y);
+                this.gridRenderer.render(combatCtx);
+                combatCtx.restore();
+            }
         }
         if (this.uiManager) this.uiManager.updateUI(this.gameState);
     }

--- a/src/renderers/gridRenderer.js
+++ b/src/renderers/gridRenderer.js
@@ -1,0 +1,71 @@
+/**
+ * 그리드 및 타일 관련 시각화를 전담하는 렌더러입니다.
+ * WebGPU를 최종 목표로 하지만, 초기에는 Canvas 2D API를 사용해 구현합니다.
+ */
+export class GridRenderer {
+    constructor(config) {
+        this.mapWidth = config.mapWidth;
+        this.mapHeight = config.mapHeight;
+        this.tileSize = config.tileSize;
+        this.lineColor = config.lineColor || 'rgba(255, 255, 255, 0.1)';
+        this.lineWidth = config.lineWidth || 1;
+
+        // GridRenderer 내부에 타일 렌더링을 위한 엔진을 둡니다.
+        this.tileRenderEngine = new TileRenderEngine();
+    }
+
+    /**
+     * 지정된 캔버스 컨텍스트에 그리드를 그립니다.
+     * @param {CanvasRenderingContext2D} ctx - 그리기 작업을 수행할 2D 컨텍스트
+     */
+    render(ctx) {
+        this.tileRenderEngine.drawGridLines(
+            ctx,
+            this.mapWidth,
+            this.mapHeight,
+            this.tileSize,
+            this.lineColor,
+            this.lineWidth
+        );
+    }
+}
+
+/**
+ * \uD83C\uDF08 \uD0C0\uC77C \uB80C\uB354\uB9C1 \uC5D4\uC9C4 (TileRenderEngine)
+ * \uAE30\uBCF8\uC801\uC778 \uADF8\uB9AC\uB4DC \uD0C0\uC77C \uACBD\uACC4\uC120\uC744 \uADF8\uB9AC\uB294 \uC5F0\uD569\uC744 \uB2E8\uB2F4\uD569\uB2C8\uB2E4.
+ */
+class TileRenderEngine {
+    /**
+     * \uD0C0\uC77C \uACBD\uACC4\uC5D0 \uB530\uB77C \uADF8\uB9AC\uB4DC \uC120\uC744 \uADF8\uB9BD\uB2C8\uB2E4.
+     * @param {CanvasRenderingContext2D} ctx
+     * @param {number} mapWidth - \uD53C\uD06C\uC5B4\uB9AC\uB4DC \uB2E8\uC704\uC758 \uB9F5 \uB108\uBE44
+     * @param {number} mapHeight - \uD53C\uD06C\uC5B4\uB9AC\uB4DC \uB2E8\uC704\uC758 \uB9F5 \uB192\uC774
+     * @param {number} tileSize - \uD0C0\uC77C \uD558\uB098\uC758 \uD06C\uAE30 (\uD53C\uD06C\uC5B4\uB9AC\uB4DC)
+     * @param {string} color - \uC120 \uC0C9\uC0C1
+     * @param {number} width - \uC120 \uAD6C\uAE30
+     */
+    drawGridLines(ctx, mapWidth, mapHeight, tileSize, color, width) {
+        ctx.save();
+        ctx.strokeStyle = color;
+        ctx.lineWidth = width;
+
+        // \uC138\uB85C\uC120
+        for (let x = 0; x <= mapWidth; x += tileSize) {
+            ctx.beginPath();
+            ctx.moveTo(x, 0);
+            ctx.lineTo(x, mapHeight);
+            ctx.stroke();
+        }
+
+        // \uAC00\uB85C\uC120
+        for (let y = 0; y <= mapHeight; y += tileSize) {
+            ctx.beginPath();
+            ctx.moveTo(0, y);
+            ctx.lineTo(mapWidth, y);
+            ctx.stroke();
+        }
+
+        ctx.restore();
+    }
+}
+

--- a/src/worldEngine.js
+++ b/src/worldEngine.js
@@ -1,3 +1,5 @@
+import { GridRenderer } from './renderers/gridRenderer.js';
+
 export class WorldEngine {
     constructor(game, assets) {
         this.game = game;
@@ -12,6 +14,13 @@ export class WorldEngine {
         this.dragStart = { x: 0, y: 0 };
         this.isDragging = false;
         this.followPlayer = true;
+        // 월드맵용 GridRenderer 인스턴스 생성
+        this.gridRenderer = new GridRenderer({
+            mapWidth: this.worldWidth,
+            mapHeight: this.worldHeight,
+            tileSize: this.tileSize,
+            lineColor: 'rgba(255, 255, 255, 0.05)'
+        });
         // 플레이어 정보는 Game 초기화 이후 setPlayer()로 전달된다
         this.player = null;
         this.monsters = [


### PR DESCRIPTION
## Summary
- add a new `GridRenderer` component for drawing tile grids
- expose grids on both combat and world maps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e6a85e6288327893691e3839e3b8b