### PR TITLE
Add turn-based management to world map

### DIFF
--- a/src/managers/walkManager.js
+++ b/src/managers/walkManager.js
@@ -1,0 +1,26 @@
+/**
+ * 엔티티의 이동 경로를 계산하는 간단한 AI입니다.
+ */
+export class WalkManager {
+    /**
+     * 목표를 향한 다음 타일 좌표를 계산합니다. (장애물 고려 X)
+     * @param {object} startEntity - 출발 엔티티 (예: monster)
+     * @param {object} targetEntity - 목표 엔티티 (예: player)
+     * @returns {{x: number, y: number}} 다음 타일 좌표
+     */
+    getNextStep(startEntity, targetEntity) {
+        const nextTile = { x: startEntity.tileX, y: startEntity.tileY };
+        const dx = targetEntity.tileX - startEntity.tileX;
+        const dy = targetEntity.tileY - startEntity.tileY;
+
+        if (Math.abs(dx) > Math.abs(dy)) {
+            if (dx > 0) nextTile.x++;
+            else if (dx < 0) nextTile.x--;
+        } else {
+            if (dy > 0) nextTile.y++;
+            else if (dy < 0) nextTile.y--;
+        }
+
+        return nextTile;
+    }
+}

--- a/src/managers/worldTurnManager.js
+++ b/src/managers/worldTurnManager.js
@@ -1,0 +1,31 @@
+/**
+ * 게임의 턴 흐름을 관리합니다.
+ * '누구의 차례인가'와 '행동(애니메이션)이 진행 중인가'를 관리하는 핵심 지휘자입니다.
+ */
+export class WorldTurnManager {
+    /**
+     * @param {object} config.movementEngine - 현재 진행 중인 움직임이 있는지 확인하기 위함
+     * @param {Array<object>} config.entities - 턴에 참여하는 모든 엔티티 (플레이어, 몬스터 등)
+     */
+    constructor(config) {
+        this.movementEngine = config.movementEngine;
+        this.entities = config.entities;
+        // 턴 상태: 'PLAYER' (플레이어 턴), 'ENEMY' (적 턴)
+        this.currentTurn = 'PLAYER';
+    }
+
+    /** 현재 플레이어 턴인지 확인합니다. */
+    isPlayerTurn() {
+        return this.currentTurn === 'PLAYER';
+    }
+
+    /** 현재 행동(애니메이션)이 진행 중인지 확인합니다. */
+    isActionInProgress() {
+        return this.entities.some(e => this.movementEngine.isMoving(e));
+    }
+
+    /** 다음 턴으로 전환합니다. */
+    nextTurn() {
+        this.currentTurn = this.currentTurn === 'PLAYER' ? 'ENEMY' : 'PLAYER';
+    }
+}


### PR DESCRIPTION
## Summary
- implement `WorldTurnManager` and `WalkManager`
- refactor `WorldEngine` to use the new managers for a simple player/enemy turn loop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e88d216f4832789fa394e9550b1aa