### PR TITLE
Introduce modular engine skeletons

### DIFF
--- a/src/engines/actionExecutionEngine.js
+++ b/src/engines/actionExecutionEngine.js
@@ -1,0 +1,13 @@
+/**
+ * \u2699\uFE0F \uD589\uB3D9 \uC2E4\uD589 \uC5D4\uC9C4
+ * \uACB0\uC815\uB41C \uD589\uB3D9(\uC774\uB3D9, \uACF5\uACA9)\uC758 \uC2DC\uAC01\uC801/\uCC29\uC801 \uC5F0\uCD9C\uC744 \uB2E8\uB2F4\uD569\uB2C8\uB2E4.
+ */
+export class ActionExecutionEngine {
+    constructor(movementEngine) {
+        this.movementEngine = movementEngine;
+    }
+    // \uC608\uC2DC: executeMove(entity, path), executeAttack(attacker, target)
+    execute(action) {
+        // placeholder for future action execution logic
+    }
+}

--- a/src/engines/combatEngine.js
+++ b/src/engines/combatEngine.js
@@ -1,0 +1,48 @@
+/**
+ * \uC804\uD22C \uD30C\uD2B8 \uACFC\uC815.
+ * \uC18C\uADFC\uBA74 \uD130\uB110\uC81C \uC804\uD22C\uC758 \uBAA8\uB4E0 \uAC83\uC744 \uAD8C\uD55C\uD569\uB2C8\uB2E4.
+ */
+export class CombatEngine {
+    constructor(game) {
+        this.game = game;
+        this.movementEngine = game.movementEngine;
+        this.inputHandler = game.inputHandler;
+        this.mapManager = game.mapManager;
+        this.player = game.player;
+        this.monster = game.monster;
+
+        // CombatEngine \uC790\uC2E0\uB9CC\uC758 \uAC04\uB2E8\uD55C \uD130\uB110 \uAD00\uB9AC
+        this.currentTurn = 'PLAYER';
+    }
+
+    update() {
+        // \uC6C0\uC9C1\uC774\uB294 \uC560\uB2C8\uBA54\uC774\uC158 \uC911\uC5D0\uB294 \uC544\uBB34\uAC83\uB3C4 \uD558\uC9C0 \uC54A\uC2B5\uB2C8\uB2E4.
+        if (this.movementEngine.isMoving(this.player) || this.movementEngine.isMoving(this.monster)) {
+            return;
+        }
+
+        if (this.currentTurn === 'PLAYER') {
+            this.handlePlayerInput();
+        } else {
+            this.handleEnemyAI();
+        }
+    }
+
+    handlePlayerInput() {
+        // TODO: \uD50C\uB808\uC774\uC5B4 \uC785\uB825 \uCD94\uAC00
+        // ...
+        // this.currentTurn = 'ENEMY';
+    }
+
+    handleEnemyAI() {
+        // TODO: \uAC04\uB2E8\uD55C AI \uB77C\uC774\uD504
+        this.currentTurn = 'PLAYER';
+    }
+
+    render(context) {
+        // \uC804\uD22C \uC7A5\uBA74\uC5D0 \uD544\uC694\uD55C \uAC83\uB4E4\uC744 \uADF8\uB9AC\uB294\uB2E4.
+        this.mapManager.render(context);
+        this.player.draw?.(context);
+        this.monster.draw?.(context);
+    }
+}

--- a/src/engines/lineOfSightEngine.js
+++ b/src/engines/lineOfSightEngine.js
@@ -1,0 +1,10 @@
+/**
+ * \uD83E\uDD16 \uC2DC\uC57C \uACC4\uC0B0 \uC5D4\uC9C4
+ * \uB450 \uC9C0\uC810 \uAC04\uC758 \uC2DC\uC57C(Line of Sight)\uB97C \uACC4\uC0B0\uD569\uB2C8\uB2E4.
+ */
+export class LineOfSightEngine {
+    constructor(grid) {
+        this.grid = grid;
+    }
+    // \uC608\uC2DC: isVisible(fromX, fromY, toX, toY) \uB4F1
+}

--- a/src/engines/terrainAnalysisEngine.js
+++ b/src/engines/terrainAnalysisEngine.js
@@ -1,0 +1,10 @@
+/**
+ * \uD83E\uDDE0 \uC9C0\uD615 \uBD84\uC11D \uC5D4\uC9C4
+ * \uD0C0\uC77C\uC758 \uC18D\uC131(\uC9C0\uD615, \uC774\uB3D9 \uBE44\uC6A9 \uB4F1)을 \uBD84\uC11D\uD569\uB2C8\uB2E4.
+ */
+export class TerrainAnalysisEngine {
+    constructor(grid) {
+        this.grid = grid;
+    }
+    // \uC608\uC2DC: getTileProperties(x, y), getMovementCost(x, y) \uB4F1
+}

--- a/src/engines/turnSequencingEngine.js
+++ b/src/engines/turnSequencingEngine.js
@@ -1,0 +1,14 @@
+/**
+ * \u2699\uFE0F \uD130\uB110 \uC21C\uC11C \uACB0\uC815 \uC5D4\uC9C4
+ * \uD130\uB110\uC758 \uC21C\uC11C\uB97C \uACB0\uC815\uD569\uB2C8\uB2E4. (\uB2E8\uC21C \uC21C\uC11C, \uBBFC\uCDE8\uC131 \uAE30\uBC18 \uB4F1)
+ */
+export class TurnSequencingEngine {
+    constructor(entities) {
+        this.entities = entities;
+        this.currentIndex = 0;
+    }
+    // \uC608\uC2DC: getNextEntity()
+    getCurrentEntity() {
+        return this.entities[this.currentIndex];
+    }
+}

--- a/src/engines/worldEngine.js
+++ b/src/engines/worldEngine.js
@@ -1,0 +1,22 @@
+/**
+ * \uC804\uB7B5 \uD30C\uD2B8 \uACFC\uC815.
+ * \uC6D0\uB4DC\uB9F5\uC758 \uBAA8\uB4E0 \uAC83\uC744 \uAD8C\uD55C\uD558\uB294 '\uD130\uB110\uC81C \uC804\uB7B5 \uAC8C\uC784 \uC5D4\uC9C4'\uC785\uB2C8\uB2E4.
+ */
+export class WorldEngine {
+    constructor(game) {
+        this.game = game;
+        // \uC6D0\uB4DC\uB9F5\uC740 \uC790\uC2E0\uB9CC\uC758 \uAC00\uB4E4\uD55C GridManager\uC640 TurnManager\uB97C \uAC16\uC2B5\uB2C8\uB2E4.
+        this.gridManager = game.gridManager;
+        this.turnManager = game.turnManager;
+    }
+
+    update() {
+        // \uC6D0\uB4DC\uB9F5\uC758 \uD130\uB110 \uB85C\uC9C1 \uCC98\uB9AC
+        // e.g., this.turnManager.update();
+    }
+
+    render(context) {
+        // \uC6D0\uB4DC\uB9F5 \uADF8\uB9AC\uAE30
+        // e.g., this.gridManager.render();
+    }
+}

--- a/src/managers/gridManager.js
+++ b/src/managers/gridManager.js
@@ -1,0 +1,22 @@
+import { TerrainAnalysisEngine } from '../engines/terrainAnalysisEngine.js';
+import { LineOfSightEngine } from '../engines/lineOfSightEngine.js';
+
+/**
+ * \uADF8\uB9AC\uB4DC \uB370\uC774\uD130\uC640 \uAD00\uB828\uB41C \uBAA8\uB4E0 \uAC83\uC744 \uCD1D\uAD00\uD569\uB2C8\uB2E4.
+ * \uC2E4\uC81C \uBD84\uC11D\uC740 \uD558\uC704 \uC5D4\uC9C4\uB4E4\uC5D0\uAC8C \uC704\uC785\uD569\uB2C8\uB2E4.
+ */
+export class GridManager {
+    constructor() {
+        // \uB098\uC911\uC5D0 \uB9E4\uD551\uB370\uC774\uD130\uB97C \uB85C\uB4DC\uD558\uC5EC \uC5EC\uAE30\uC5D0 \uC800\uC7A5\uD569\uB2C8\uB2E4.
+        this.gridData = [];
+
+        // \uC804\uBB38 \uBD84\uC11D \uC5D4\uC9C4\uB4E4\uC744 \uACE0\uC6A9\uD569\uB2C8\uB2E4.
+        this.terrainAnalysisEngine = new TerrainAnalysisEngine(this.gridData);
+        this.lineOfSightEngine = new LineOfSightEngine(this.gridData);
+    }
+
+    // GridManager\uB294 \uC774\uC81C "\uC774 \uD0C0\uC77C \uC18D\uC131 \uBB34\uC5C7?" \uD558\uACE0 \uBB3C\uC5B4\uBCF4\uAE30\uB9CC \uD558\uBA74 \uB429\uB2C8\uB2E4.
+    getTileProperties(x, y) {
+        return this.terrainAnalysisEngine.getTileProperties?.(x, y);
+    }
+}

--- a/src/managers/turnManager.js
+++ b/src/managers/turnManager.js
@@ -1,59 +1,32 @@
-// src/turnManager.js
-// 턴 기반의 상태 변화를 관리할 매니저 (구멍만 파기)
+import { TurnSequencingEngine } from '../engines/turnSequencingEngine.js';
+import { ActionExecutionEngine } from '../engines/actionExecutionEngine.js';
+
+/**
+ * \uD130\uB11B\uC81C \uC2DC\uC2A4\uD15C\uC758 \uC9C0\uD558\uC790. \uD130\uB110 \uC21C\uC11C\uC640 \uD589\uB3D9 \uC2E4\uD589\uC744 \uC9C0\uC2DC\uD569\uB2C8\uB2E4.
+ * (WorldEngine\uACFC CombatEngine\uC774 \uAC01\uAC01 \uC790\uC2E0\uC758 TurnManager\uB97C \uAC16\uACE0 \uC788\uC744 \uC218 \uC788\uC2B5\uB2C8\uB2E4)
+ */
 export class TurnManager {
-    constructor() {
-        this.turnCount = 0;
-        this.framesPerTurn = 100; // 100프레임을 1턴으로 간주
-        this.currentFrame = 0;
+    constructor(entities, movementEngine) {
+        // \uD130\uB110 \uAD00\uB9AC \uC804\uBB38 \uC5D4\uC9C4\uB4E4\uC744 \uACE0\uC6A9\uD569\uB2C8\uB2E4.
+        this.turnSequencingEngine = new TurnSequencingEngine(entities);
+        this.actionExecutionEngine = new ActionExecutionEngine(movementEngine);
+
+        this.currentPhase = 'PLAYER_TURN'; // \uC608: PLAYER_TURN, ENEMY_TURN
     }
 
-    update(entities, { eventManager = null, player = null, parasiteManager = null } = {}) {
-        this.currentFrame++;
-        if (this.currentFrame >= this.framesPerTurn) {
-            this.currentFrame = 0;
-            this.turnCount++;
+    update() {
+        // "\uB2E4\uC74C \uD589\uB3D9\uD560 \uC0AC\uB78C \uB204\uAD6C\uC57C?"
+        const currentEntity = this.turnSequencingEngine.getCurrentEntity();
 
-            for (const e of entities) {
-                if (e.fullness !== undefined) {
-                    let loss = 0;
-                    if ((e.isFriendly || e.isPlayer) && e.prevTurnPos) {
-                        if (e.x !== e.prevTurnPos.x || e.y !== e.prevTurnPos.y) {
-                            loss = 0.1;
-                        }
-                    } else if (parasiteManager?.hasParasite(e)) {
-                        loss = 0.1; // 몬스터는 이동 여부와 상관없이 기본 소모
-                    }
-                    if (parasiteManager?.hasParasite(e)) {
-                        loss = +(loss * 2).toFixed(2);
-                    }
-                    if (loss > 0) {
-                        e.fullness = Math.max(0, +(e.fullness - loss).toFixed(2));
-                    }
-                    e.prevTurnPos = { x: e.x, y: e.y };
-                    if (e.fullness <= 0) {
-                        eventManager?.publish('log', { message: `${e.constructor.name}이(가) 굶주림으로 쓰러졌습니다.` });
-                        if (e.isPlayer) {
-                            eventManager?.publish('game_over', {});
-                        } else {
-                            eventManager?.publish('entity_death', { attacker: null, victim: e });
-                        }
-                        continue;
-                    } else if (e.fullness < 20) {
-                        eventManager?.publish('log', { message: `${e.constructor.name}의 배부름이 위험합니다!`, color: 'orange' });
-                    }
-                }
+        // "AI\uC5D0\uAC8C \uBB34\uC5ED \uD560\uC9C0 \uBB3C\uC5B4\uBCF4\uACE0 \uD589\uB3D9 \uACB0\uC815"
+        const action = this.getActionFor(currentEntity);
 
-                if (e.affinity !== undefined && e !== player && e.isFriendly) {
-                    let gain = 0.1;
-                    if (parasiteManager?.hasParasite(e)) gain *= 0.5;
-                    e.affinity = Math.min(e.maxAffinity, +(e.affinity + gain).toFixed(2));
-                    if (e.affinity <= 0) {
-                        eventManager?.publish('log', { message: `${e.constructor.name}의 호감도가 바닥나 파티를 떠났습니다.` });
-                    } else if (e.affinity < 20) {
-                        eventManager?.publish('log', { message: `${e.constructor.name}의 호감도가 위험합니다!`, color: 'orange' });
-                    }
-                }
-            }
-        }
+        // "\uACB0\uC815\uB41C \uD589\uB3D9\uC744 \uC2E4\uD589(\uC5F0\uCD9C)\uD574!"
+        this.actionExecutionEngine.execute(action);
+    }
+
+    getActionFor(entity) {
+        // TODO: AI \uC5F0\uB3D9 \uD558\uACE0 \uC720\uB2DB \uC785\uB825 \uCCB4\uD06C
+        return null;
     }
 }

--- a/src/renderers/debugOverlayEngine.js
+++ b/src/renderers/debugOverlayEngine.js
@@ -1,0 +1,12 @@
+/**
+ * \uD83C\uDFA8 \uB514\uBC84\uADF8 \uC624\uBC84\uB808\uC774 \uC5D4\uC9C4
+ * \uAC1C\uBC1C \uC911 \uD544\uC694\uD55C \uB514\uBC84\uADF8 \uC815\uBCF4(\uC88C\uD45C, \uACBD\uB85C \uB4F1)\uB97C \uADF8\uB9AC\uB294 \uC5D4\uC9C4\uC785\uB2C8\uB2E4.
+ */
+export class DebugOverlayEngine {
+    constructor(config) {
+        this.config = config;
+    }
+    render(ctx) {
+        // \uC608: \uD0C0\uC77C \uC88C\uD45C, AI \uC810\uC218 \uB4F1 \uD14D\uC2A4\uD2B8 \uB80C\uB354\uB9C1
+    }
+}

--- a/src/renderers/effectRenderEngine.js
+++ b/src/renderers/effectRenderEngine.js
@@ -1,0 +1,12 @@
+/**
+ * \uD83C\uDFA8 \uD6A8\uACFC \uB80C\uB354\uB9C1 \uC5D4\uC9C4
+ * \uC774\uB3D9/\uACF5\uACA9 \uBC94\uC704 \uD45C\uC2DC, \uC2A4\uD0AC \uC774\uD15C \uB4F1 \uB3D9\uC801 \uD6A8\uACFC\uB97C \uADF8\uB9AC\uB294 \uC5D4\uC9C4\uC785\uB2C8\uB2E4.
+ */
+export class EffectRenderEngine {
+    constructor(config) {
+        this.config = config;
+    }
+    render(ctx) {
+        // \uC608: \uC774\uB3D9 \uAC00\uB2A5 \uBC94\uC704 \uD558\uC774\uB77C\uC774\uC2A4 \uB85C\uC9C0\uD06C
+    }
+}

--- a/src/renderers/gridRenderer.js
+++ b/src/renderers/gridRenderer.js
@@ -2,6 +2,13 @@
  * 그리드 및 타일 관련 시각화를 전담하는 렌더러입니다.
  * WebGPU를 최종 목표로 하지만, 초기에는 Canvas 2D API를 사용해 구현합니다.
  */
+import { TileRenderEngine } from './tileRenderEngine.js';
+import { EffectRenderEngine } from './effectRenderEngine.js';
+import { DebugOverlayEngine } from './debugOverlayEngine.js';
+
+/**
+ * 시각화 전문가. 그리드와 관련된 모든 렌더링을 지시합니다.
+ */
 export class GridRenderer {
     constructor(config) {
         this.mapWidth = config.mapWidth;
@@ -10,15 +17,20 @@ export class GridRenderer {
         this.lineColor = config.lineColor || '#000';
         this.lineWidth = config.lineWidth || 6;
 
-        // GridRenderer 내부에 타일 렌더링을 위한 엔진을 둡니다.
-        this.tileRenderEngine = new TileRenderEngine();
+        // 렌더링 전문 엔진들을 고용합니다.
+        this.tileRenderEngine = new TileRenderEngine(config);
+        this.effectRenderEngine = new EffectRenderEngine(config);
+        this.debugOverlayEngine = new DebugOverlayEngine(config);
+
+        this.showDebug = true; // 디버그 모드 on/off
     }
 
     /**
      * 지정된 캔버스 컨텍스트에 그리드를 그립니다.
      * @param {CanvasRenderingContext2D} ctx - 그리기 작업을 수행할 2D 컨텍스트
      */
-    render(ctx) {
+    render(ctx, gridData = null, effectData = null, debugData = null) {
+        // 각 엔진에게 자신의 전문 분야를 그리라고 지시합니다.
         this.tileRenderEngine.drawGridLines(
             ctx,
             this.mapWidth,
@@ -27,45 +39,10 @@ export class GridRenderer {
             this.lineColor,
             this.lineWidth
         );
-    }
-}
-
-/**
- * \uD83C\uDF08 \uD0C0\uC77C \uB80C\uB354\uB9C1 \uC5D4\uC9C4 (TileRenderEngine)
- * \uAE30\uBCF8\uC801\uC778 \uADF8\uB9AC\uB4DC \uD0C0\uC77C \uACBD\uACC4\uC120\uC744 \uADF8\uB9AC\uB294 \uC5F0\uD569\uC744 \uB2E8\uB2F4\uD569\uB2C8\uB2E4.
- */
-class TileRenderEngine {
-    /**
-     * \uD0C0\uC77C \uACBD\uACC4\uC5D0 \uB530\uB77C \uADF8\uB9AC\uB4DC \uC120\uC744 \uADF8\uB9BD\uB2C8\uB2E4.
-     * @param {CanvasRenderingContext2D} ctx
-     * @param {number} mapWidth - \uD53C\uD06C\uC5B4\uB9AC\uB4DC \uB2E8\uC704\uC758 \uB9F5 \uB108\uBE44
-     * @param {number} mapHeight - \uD53C\uD06C\uC5B4\uB9AC\uB4DC \uB2E8\uC704\uC758 \uB9F5 \uB192\uC774
-     * @param {number} tileSize - \uD0C0\uC77C \uD558\uB098\uC758 \uD06C\uAE30 (\uD53C\uD06C\uC5B4\uB9AC\uB4DC)
-     * @param {string} color - \uC120 \uC0C9\uC0C1
-     * @param {number} width - \uC120 \uAD6C\uAE30
-     */
-    drawGridLines(ctx, mapWidth, mapHeight, tileSize, color, width) {
-        ctx.save();
-        ctx.strokeStyle = color;
-        ctx.lineWidth = width;
-
-        // \uC138\uB85C\uC120
-        for (let x = 0; x <= mapWidth; x += tileSize) {
-            ctx.beginPath();
-            ctx.moveTo(x, 0);
-            ctx.lineTo(x, mapHeight);
-            ctx.stroke();
+        this.effectRenderEngine.render(ctx, effectData);
+        if (this.showDebug) {
+            this.debugOverlayEngine.render(ctx, debugData);
         }
-
-        // \uAC00\uB85C\uC120
-        for (let y = 0; y <= mapHeight; y += tileSize) {
-            ctx.beginPath();
-            ctx.moveTo(0, y);
-            ctx.lineTo(mapWidth, y);
-            ctx.stroke();
-        }
-
-        ctx.restore();
     }
 }
 

--- a/src/renderers/tileRenderEngine.js
+++ b/src/renderers/tileRenderEngine.js
@@ -1,0 +1,38 @@
+/**
+ * \uD83C\uDF08 \uD0C0\uC77C \uB80C\uB354\uB9C1 \uC5D4\uC9C4
+ * \uAE30\uBCF8\uC801\uC778 \uADF8\uB9AC\uB4DC \uD0C0\uC77C \uACBD\uACC4\uC120\uC744 \uADF8\uB9AC\uB294 \uC5F0\uD569\uC785\uB2C8\uB2E4.
+ */
+export class TileRenderEngine {
+    /**
+     * \uD0C0\uC77C \uACBD\uACC4\uC5D0 \uB530\uB77C \uADF8\uB9AC\uB4DC \uC120\uC744 \uADF8\uB9BD\uB2C8\uB2E4.
+     * @param {CanvasRenderingContext2D} ctx
+     * @param {number} mapWidth - \uD53C\uD06C\uC5B4\uB9AC\uB4DC \uB2E8\uC704\uC758 \uB9F5 \uB108\uBE44
+     * @param {number} mapHeight - \uD53C\uD06C\uC5B4\uB9AC\uB4DC \uB2E8\uC704\uC758 \uB9F5 \uB192\uC774
+     * @param {number} tileSize - \uD0C0\uC77C \uD558\uB098\uC758 \uD06C\uAE30 (\uD53C\uD06C\uC5B4\uB9AC\uB4DC)
+     * @param {string} color - \uC120 \uC0C9\uC0C1
+     * @param {number} width - \uC120 \uAD6C\uAE30
+     */
+    drawGridLines(ctx, mapWidth, mapHeight, tileSize, color, width) {
+        ctx.save();
+        ctx.strokeStyle = color;
+        ctx.lineWidth = width;
+
+        // \uC138\uB85C\uC120
+        for (let x = 0; x <= mapWidth; x += tileSize) {
+            ctx.beginPath();
+            ctx.moveTo(x, 0);
+            ctx.lineTo(x, mapHeight);
+            ctx.stroke();
+        }
+
+        // \uAC00\uB85C\uC120
+        for (let y = 0; y <= mapHeight; y += tileSize) {
+            ctx.beginPath();
+            ctx.moveTo(0, y);
+            ctx.lineTo(mapWidth, y);
+            ctx.stroke();
+        }
+
+        ctx.restore();
+    }
+}


### PR DESCRIPTION
## Summary
- create new skeleton engines and renderers for future world map/combat logic
- refactor `GridRenderer` to delegate to specialized render engines
- add `GridManager` and lighter `TurnManager`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e8cd85e148327bd37029767380ae0