### PR TITLE
Handle empty entity list in turn engine

### DIFF
--- a/src/engines/turnSequencingEngine.js
+++ b/src/engines/turnSequencingEngine.js
@@ -3,12 +3,18 @@
  * \uD130\uB110\uC758 \uC21C\uC11C\uB97C \uACB0\uC815\uD569\uB2C8\uB2E4. (\uB2E8\uC21C \uC21C\uC11C, \uBBFC\uCDE8\uC131 \uAE30\uBC18 \uB4F1)
  */
 export class TurnSequencingEngine {
-    constructor(entities) {
+    constructor(entities = []) {
+        // 엔티티 목록이 주어지지 않으면 빈 배열로 초기화하여
+        // 호출 부주의로 인한 오류를 방지합니다.
         this.entities = entities;
         this.currentIndex = 0;
     }
+
     // \uC608\uC2DC: getNextEntity()
     getCurrentEntity() {
+        // 엔티티가 없으면 null을 반환하여 상위 로직이 적절히 처리하도록 합니다.
+        if (!this.entities.length) return null;
+        this.currentIndex %= this.entities.length;
         return this.entities[this.currentIndex];
     }
 }

--- a/src/game.js
+++ b/src/game.js
@@ -166,7 +166,9 @@ export class Game {
             this.uiManager?.createSquadManagementUI();
         });
         this.saveLoadManager = new SaveLoadManager();
-        this.turnManager = new TurnManager();
+        // TurnManager \uC124\uC815: \uBAA8\uB4E0 \uC0DD\uCCB4\uAC00 \uC5C6\uB294 \uCD08\uAE30
+        // \uB370\uC774\uD130\uC640 movementEngine\uB9CC \uC804\uB2EC\uD569\uB2C8\uB2E4.
+        this.turnManager = new TurnManager([], this.movementEngine);
         this.narrativeManager = new NarrativeManager();
         this.supportEngine = new SupportEngine();
         this.factory = new CharacterFactory(assets, this);

--- a/src/managers/turnManager.js
+++ b/src/managers/turnManager.js
@@ -6,8 +6,10 @@ import { ActionExecutionEngine } from '../engines/actionExecutionEngine.js';
  * (WorldEngine\uACFC CombatEngine\uC774 \uAC01\uAC01 \uC790\uC2E0\uC758 TurnManager\uB97C \uAC16\uACE0 \uC788\uC744 \uC218 \uC788\uC2B5\uB2C8\uB2E4)
  */
 export class TurnManager {
-    constructor(entities, movementEngine) {
+    constructor(entities = [], movementEngine) {
         // \uD130\uB110 \uAD00\uB9AC \uC804\uBB38 \uC5D4\uC9C4\uB4E4\uC744 \uACE0\uC6A9\uD569\uB2C8\uB2E4.
+        // entities \uC778\uC218\uAC00 \uC81C\uACF5\uB418\uC9C0 \uC54A\uC544\uB3C4
+        // \uBE44\uC6A9\uC744 \uBC29\uC9C0\uD558\uB294 \uB8F8트 \uC124\uC815.
         this.turnSequencingEngine = new TurnSequencingEngine(entities);
         this.actionExecutionEngine = new ActionExecutionEngine(movementEngine);
 
@@ -17,6 +19,7 @@ export class TurnManager {
     update() {
         // "\uB2E4\uC74C \uD589\uB3D9\uD560 \uC0AC\uB78C \uB204\uAD6C\uC57C?"
         const currentEntity = this.turnSequencingEngine.getCurrentEntity();
+        if (!currentEntity) return;
 
         // "AI\uC5D0\uAC8C \uBB34\uC5ED \uD560\uC9C0 \uBB3C\uC5B4\uBCF4\uACE0 \uD589\uB3D9 \uACB0\uC815"
         const action = this.getActionFor(currentEntity);


### PR DESCRIPTION
## Summary
- default to an empty array in `TurnSequencingEngine`
- prevent crash in `TurnManager` when no entities are present
- pass movement engine when constructing the turn manager

## Testing
- `node run-tests.mjs` *(fails: `node` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e913d020c8327b64edd86e6460ae3