### PR TITLE
Introduce formation and squad engines

### DIFF
--- a/src/engines/CombatEngine.js
+++ b/src/engines/CombatEngine.js
@@ -3,10 +3,22 @@ import { EFFECTS } from '../data/effects.js';
 export class CombatEngine {
     constructor(game) {
         this.game = game;
+        this.battleContext = null;
+    }
+
+    /**
+     * FormationEngine\uC5D0\uC11C \uC804\uD22C \uC815\uBCF4\uB97C \uBC1B\uC544 \uC2DC\uC791\uD569\uB2C8\uB2E4.
+     * @param {object} context
+     */
+    start(context) {
+        console.log('\uC2E4\uC2DC\uAC04 \uC804\uD22C \uC2DC\uC791!', context);
+        this.battleContext = context;
     }
 
     update(deltaTime) {
         const game = this.game;
+
+        if (!this.battleContext) return;
 
         game.handleCameraReset();
 
@@ -130,9 +142,16 @@ export class CombatEngine {
         ];
         microEngine.update(allItems);
         eventManager.publish('debug', { tag: 'Frame', message: '--- Frame Update End ---' });
+
+        const result = this.checkCombatEnd();
+        if (result) {
+            this.game.endCombat(result);
+            this.battleContext = null;
+        }
     }
 
     render() {
+        if (!this.battleContext) return;
         const game = this.game;
         const { layerManager, gameState, mapManager, itemManager, monsterManager, mercenaryManager, fogManager, uiManager } = game;
         const assets = game.loader.assets;
@@ -224,5 +243,14 @@ export class CombatEngine {
         if (game.uiManager && game.gameState.currentState === 'COMBAT') {
             uiManager.updateUI(gameState);
         }
+    }
+
+    checkCombatEnd() {
+        const { mercenaryManager, monsterManager } = this.game;
+        const allEnemiesDefeated = monsterManager.monsters.every(m => m.hp <= 0);
+        const playerDead = this.game.gameState.player.hp <= 0;
+        if (allEnemiesDefeated) return { result: 'VICTORY', rewards: [] };
+        if (playerDead) return { result: 'DEFEAT' };
+        return null;
     }
 }

--- a/src/engines/formationEngine.js
+++ b/src/engines/formationEngine.js
@@ -1,0 +1,35 @@
+/**
+ * \uBD80\uB300 \uC815\uBE44 \uD30C\uD2B8 \uACFC\uC815.\n * \uC804\uD22C \uC2DC\uC791 \uC804 \uC5F0\uC7A5\uC5D0\uC11C \uC720\uB2DB\uC744 \uBC30\uCE58\uD558\uACE0 \uC9C4\uD615\uC744 \uAD6C\uD569\uB2C8\uB2E4.\n */
+export class FormationEngine {
+    constructor(game) {
+        this.game = game;
+        this.inputHandler = game.inputHandler;
+        this.uiManager = game.uiManager;
+        this.battleContext = null;
+    }
+
+    /**
+     * WorldEngine\uC5D0\uC11C \uC804\uD22C \uC0C1\uD0DC \uC815\uBCF4\uB97C \uBC1B\uC544 \uC2DC\uC791\uD569\uB2C8\uB2E4.
+     * @param {object} context - { enemyUnit: object, terrain: string, ... }
+     */
+    start(context) {
+        console.log('\uBD80\uB300 \uC815\uBE44 \uC2DC\uC791!', context);
+        this.battleContext = context;
+        // TODO: UI \uBCF4\uC6B8 \uB54C \uC801\uC6A9\uD560 \uB9CC\uD55C \uCF54\uB4DC \uC774\uB2C8 UIManager \uB610\uB294 game.js \uB97C \uC0AC\uC6A9\n        this.uiManager.showPanel?.('squad-management-ui');
+    }
+
+    update(deltaTime) {
+        if (!this.battleContext) return;
+        // \uBD80\uB300 \uC815\uBE44 \uD654\uBA74\uC758 UI \uC0AC\uC6A9\uC790 \uC0B0\uD638\uC791 \uCCB4\uD06C
+        if (this.uiManager.isCombatStartButtonPressed?.()) {
+            this.battleContext.playerFormation = this.uiManager.getCurrentFormation?.();
+            this.game.startCombat(this.battleContext);
+            this.battleContext = null;
+        }
+    }
+
+    render(context) {
+        if (!this.battleContext) return;
+        // TODO: \uC720\uB2DB \uBC30\uCE58 \uC2DC\uAC04 \uD654\uBA74 \uADF8\uB9AC\uAE30. \uC774\uC81C UIManager \uC81C\uACF5 \uB514\uD3F4\uD2B8 \uC774\uB85C \uB0A8\uACA8 \uB458 \uC218 \uC788\uB2E4.
+    }
+}

--- a/src/engines/formationLayoutEngine.js
+++ b/src/engines/formationLayoutEngine.js
@@ -1,0 +1,28 @@
+/**
+ * \uC9C4\uD615 \uC704\uCE58 \uACC4\uC0B0 \uC804\uBB38 \uC5D4\uC9C4
+ */
+export class FormationLayoutEngine {
+    constructor(config) {
+        this.rows = config.rows;
+        this.cols = config.cols;
+        this.tileSize = config.tileSize;
+        this.orientation = config.orientation;
+        this.rotation = config.rotation;
+    }
+
+    getSlotPosition(slotIndex) {
+        if (slotIndex < 0 || slotIndex >= this.rows * this.cols) return { x: 0, y: 0 };
+        const row = Math.floor(slotIndex / this.cols);
+        const col = slotIndex % this.cols;
+        const centerRow = Math.floor(this.rows / 2);
+        const centerCol = Math.floor(this.cols / 2);
+        const orientedCol = this.orientation === 'RIGHT' ? (this.cols - 1 - col) : col;
+        const relativeX = (orientedCol - centerCol) * this.tileSize;
+        const relativeY = (row - centerRow) * this.tileSize;
+        const cosR = Math.cos(this.rotation);
+        const sinR = Math.sin(this.rotation);
+        const rotatedX = relativeX * cosR - relativeY * sinR;
+        const rotatedY = relativeX * sinR + relativeY * cosR;
+        return { x: rotatedX, y: rotatedY };
+    }
+}

--- a/src/engines/squadAssignmentEngine.js
+++ b/src/engines/squadAssignmentEngine.js
@@ -1,0 +1,36 @@
+/**
+ * \uBD84\uB300 \uD3B8\uC131 \uC804\uBB38 \uC5D4\uC9C4
+ */
+export class SquadAssignmentEngine {
+    constructor(squads, unassignedMercs, mercenaryManager) {
+        this.squads = squads;
+        this.unassignedMercs = unassignedMercs;
+        this.mercenaryManager = mercenaryManager;
+    }
+
+    assign({ mercId, toSquadId }) {
+        for (const squad of Object.values(this.squads)) {
+            squad.members.delete(mercId);
+        }
+        this.unassignedMercs.delete(mercId);
+
+        const merc = this.mercenaryManager.getMercenaries().find(m => m.id === mercId);
+        if (!merc) return;
+
+        if (toSquadId && this.squads[toSquadId]) {
+            this.squads[toSquadId].members.add(mercId);
+            merc.squadId = toSquadId;
+            console.log(`[편성 엔진] 용병 ${mercId}를 ${this.squads[toSquadId].name}에 편성.`);
+        } else {
+            this.unassignedMercs.add(mercId);
+            merc.squadId = null;
+            console.log(`[편성 엔진] 용병 ${mercId}를 미편성 상태로 변경.`);
+        }
+    }
+
+    register(merc) {
+        if (!merc) return;
+        this.unassignedMercs.add(merc.id);
+        merc.squadId = null;
+    }
+}

--- a/src/engines/worldEngine.js
+++ b/src/engines/worldEngine.js
@@ -1,22 +1,34 @@
 /**
- * \uC804\uB7B5 \uD30C\uD2B8 \uACFC\uC815.
- * \uC6D0\uB4DC\uB9F5\uC758 \uBAA8\uB4E0 \uAC83\uC744 \uAD8C\uD55C\uD558\uB294 '\uD130\uB110\uC81C \uC804\uB7B5 \uAC8C\uC784 \uC5D4\uC9C4'\uC785\uB2C8\uB2E4.
+ * \uC6D0\uB4DC \uD130\uB110\uC81C \uC804\uB7B5 \uAC8C\uC784 \uC5D4\uC9C4
+ * \uC6D0\uB4DC\uB9F5 \uD0ED \uD751\uBCF5 \uC5ED\uD560\uC744 \uC2E4\uD589\uD569\uB2C8\uB2E4.
  */
 export class WorldEngine {
     constructor(game) {
         this.game = game;
-        // \uC6D0\uB4DC\uB9F5\uC740 \uC790\uC2E0\uB9CC\uC758 \uAC00\uB4E4\uD55C GridManager\uC640 TurnManager\uB97C \uAC16\uC2B5\uB2C8\uB2E4.
         this.gridManager = game.gridManager;
         this.turnManager = game.turnManager;
+        this.monsters = [];
     }
 
     update() {
-        // \uC6D0\uB4DC\uB9F5\uC758 \uD130\uB110 \uB85C\uC9C1 \uCC98\uB9AC
-        // e.g., this.turnManager.update();
+        const encounteredEnemy = this.checkForEncounters();
+        if (encounteredEnemy) {
+            const terrain = this.getTerrainAt(this.game.player.tileX, this.game.player.tileY);
+            const encounterContext = { enemyUnit: encounteredEnemy, terrain };
+            this.game.setupFormation(encounterContext);
+        }
     }
 
     render(context) {
-        // \uC6D0\uB4DC\uB9F5 \uADF8\uB9AC\uAE30
-        // e.g., this.gridManager.render();
+        // TODO: \uC6D0\uB4DC\uB9F5 \uADF8\uB9AC\uAE30
+    }
+
+    checkForEncounters() {
+        const player = this.game.player;
+        return this.monsters.find(m => !m.isDefeated && Math.abs(m.x - player.x) < 30 && Math.abs(m.y - player.y) < 30) || null;
+    }
+
+    getTerrainAt(x, y) {
+        return 'plains';
     }
 }

--- a/src/managers/formationManager.js
+++ b/src/managers/formationManager.js
@@ -1,18 +1,18 @@
+import { FormationLayoutEngine } from '../engines/formationLayoutEngine.js';
+
 export class FormationManager {
     constructor(rows = 5, cols = 5, tileSize = 192, orientation = 'LEFT', rotation = 0) {
-        // sanitize parameters to avoid invalid array length errors
         this.rows = Math.max(1, Math.floor(Number(rows) || 5));
         this.cols = Math.max(1, Math.floor(Number(cols) || 5));
-        this.tileSize = tileSize;
-        this.orientation = orientation; // LEFT or RIGHT
-        this.rotation = rotation; // radian angle to rotate grid positions
         this.slots = Array.from({ length: this.rows * this.cols }, () => new Set());
+        this.layoutEngine = new FormationLayoutEngine({ rows: this.rows, cols: this.cols, tileSize, orientation, rotation });
     }
 
     resize(rows, cols) {
         this.rows = Math.max(1, Math.floor(Number(rows) || this.rows));
         this.cols = Math.max(1, Math.floor(Number(cols) || this.cols));
         this.slots = Array.from({ length: this.rows * this.cols }, () => new Set());
+        this.layoutEngine = new FormationLayoutEngine({ ...this.layoutEngine, rows: this.rows, cols: this.cols });
     }
 
     assign(slotIndex, entityId) {
@@ -26,27 +26,7 @@ export class FormationManager {
     }
 
     getSlotPosition(slotIndex) {
-        if (slotIndex < 0 || slotIndex >= this.slots.length) {
-            return { x: 0, y: 0 };
-        }
-        const row = Math.floor(slotIndex / this.cols);
-        const col = slotIndex % this.cols;
-
-        const centerRow = Math.floor(this.rows / 2);
-        const centerCol = Math.floor(this.cols / 2);
-        // orientation에 따라 x 좌표가 시각적으로 보이는 방향과 일치하도록 조정
-        let orientedCol = this.orientation === 'RIGHT' ? (this.cols - 1 - col) : col;
-
-        const relativeX = (orientedCol - centerCol) * this.tileSize;
-        const relativeY = (row - centerRow) * this.tileSize;
-
-        // 회전 변환을 적용
-        const cosR = Math.cos(this.rotation);
-        const sinR = Math.sin(this.rotation);
-        const rotatedX = relativeX * cosR - relativeY * sinR;
-        const rotatedY = relativeX * sinR + relativeY * cosR;
-
-        return { x: rotatedX, y: rotatedY };
+        return this.layoutEngine.getSlotPosition(slotIndex);
     }
 
     apply(origin, entityMap) {

--- a/src/managers/squadManager.js
+++ b/src/managers/squadManager.js
@@ -1,4 +1,5 @@
 import { STRATEGY } from './ai-managers.js';
+import { SquadAssignmentEngine } from '../engines/squadAssignmentEngine.js';
 
 export class SquadManager {
     constructor(eventManager, mercenaryManager) {
@@ -15,6 +16,8 @@ export class SquadManager {
         this.unassignedMercs = new Set(
             this.mercenaryManager.getMercenaries().map(m => m.id)
         );
+
+        this.assignmentEngine = new SquadAssignmentEngine(this.squads, this.unassignedMercs, this.mercenaryManager);
         if (this.eventManager) {
             this.eventManager.subscribe('squad_assign_request', d => this.handleSquadAssignment(d));
             this.eventManager.subscribe('squad_strategy_change_request', d => this.setSquadStrategy(d));
@@ -23,28 +26,12 @@ export class SquadManager {
     }
 
     registerMercenary(merc) {
-        if (!merc) return;
-        this.unassignedMercs.add(merc.id);
-        merc.squadId = null;
+        this.assignmentEngine.register(merc);
     }
 
     handleSquadAssignment({ mercId, toSquadId }) {
-        for (const squad of Object.values(this.squads)) {
-            squad.members.delete(mercId);
-        }
-        this.unassignedMercs.delete(mercId);
-        if (toSquadId && this.squads[toSquadId]) {
-            this.squads[toSquadId].members.add(mercId);
-            const merc = this.mercenaryManager.getMercenaries().find(m => m.id === mercId);
-            if (merc) merc.squadId = toSquadId;
-            console.log(`용병 ${mercId}를 ${this.squads[toSquadId].name}에 편성했습니다.`);
-        } else {
-            this.unassignedMercs.add(mercId);
-            const merc = this.mercenaryManager.getMercenaries().find(m => m.id === mercId);
-            if (merc) merc.squadId = null;
-            console.log(`용병 ${mercId}를 미편성 상태로 변경했습니다.`);
-        }
-        this.eventManager?.publish('squad_data_changed', { squads: this.squads });
+        this.assignmentEngine.assign({ mercId, toSquadId });
+        this.eventManager?.publish("squad_data_changed", { squads: this.squads });
     }
 
     setSquadStrategy(squadIdOrObj, maybeStrategy) {


### PR DESCRIPTION
## Summary
- add FormationEngine to handle pre-battle setup
- split layout logic into FormationLayoutEngine
- extract squad assignment logic into SquadAssignmentEngine
- update FormationManager and SquadManager to use new engines
- add simple WorldEngine encounter handling
- refactor Game state transitions with setup/start/end combat helpers
- allow CombatEngine to start battles from context

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e9626cbf48327b17f6f0a42a3cd1c