### PR TITLE
Implement mercenary hire event propagation

### DIFF
--- a/src/managers/mercenaryManager.js
+++ b/src/managers/mercenaryManager.js
@@ -43,6 +43,10 @@ export class MercenaryManager {
                 this.traitManager.applyTraits(merc, TRAITS);
             }
             this.mercenaries.push(merc);
+            // 고용이 완료되면 다른 매니저들이 반응할 수 있도록 이벤트를 발행한다.
+            if (this.eventManager) {
+                this.eventManager.publish('mercenary_hired', { mercenary: merc });
+            }
         }
         return merc;
     }

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -76,6 +76,12 @@ export class UIManager {
                     if (ent) this.eventManager.publish('stats_changed', { entity: ent });
                 });
             });
+
+            // 용병 고용 시 UI 목록을 즉시 갱신합니다.
+            this.eventManager.subscribe('mercenary_hired', () => {
+                console.log('새 용병 고용 이벤트 수신! UI를 업데이트합니다.');
+                this.renderMercenaryList();
+            });
         }
 
         this.draggables = [];


### PR DESCRIPTION
## Summary
- fire `mercenary_hired` when a mercenary is successfully created
- refresh mercenary list UI when the hire event occurs

## Testing
- `node run-tests.mjs`

------
https://chatgpt.com/codex/tasks/task_e_685ea34eb2f88327b3f4cb6748c9ffa7