### PR TITLE
Render troop counts on world map

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -61,6 +61,8 @@ import { TooltipManager } from './managers/tooltipManager.js';
 import { CombatEngine } from "./engines/CombatEngine.js";
 import { MovementEngine } from './engines/movementEngine.js';
 import { GridRenderer } from './renderers/gridRenderer.js';
+import { GroupManager } from './managers/groupManager.js';
+import { WorldmapRenderManager } from './rendering/worldMapRenderManager.js';
 
 export class Game {
     constructor() {
@@ -134,6 +136,7 @@ export class Game {
         this.eventManager = new EventManager();
         this.tooltipManager = new TooltipManager();
         this.entityManager = new EntityManager(this.eventManager);
+        this.groupManager = new GroupManager(this.eventManager, this.entityManager.getEntityById.bind(this.entityManager));
         // InputHandler를 생성할 때 game 객체(this)를 전달합니다.
         this.inputHandler = new InputHandler(this);
         this.combatLogManager = new CombatLogManager(this.eventManager);
@@ -177,7 +180,8 @@ export class Game {
             entityManager: this.entityManager,
         });
         // 월드맵 로직을 담당하는 엔진
-        this.worldEngine = new WorldEngine(this, assets, this.movementEngine);
+        this.worldMapRenderManager = new WorldmapRenderManager(this.groupManager);
+        this.worldEngine = new WorldEngine(this, assets, this.movementEngine, this.worldMapRenderManager);
         this.combatEngine = new CombatEngine(this);
 
         // --- GridRenderer 인스턴스 생성 ---
@@ -426,6 +430,7 @@ export class Game {
             if (consumable) monster.consumables.push(consumable);
 
             this.monsterManager.addMonster(monster);
+            this.groupManager.addMember(monster);
             monsterSquad.push(monster);
         }
         const monsterEntityMap = {};
@@ -479,6 +484,7 @@ export class Game {
             followPlayer: true
         };
         this.playerGroup.addMember(player);
+        this.groupManager.addMember(player);
         // Game 인스턴스에서 직접 플레이어에 접근할 수 있도록 참조를 저장합니다.
         this.player = player;
         // 월드 엔진에서도 동일한 플레이어 데이터를 사용하도록 설정
@@ -606,6 +612,7 @@ export class Game {
                         this.laneAssignmentManager.assignMercenaryToLane(newMerc);
                         this.entityManager.addEntity(newMerc);
                         this.playerGroup.addMember(newMerc);
+                        this.groupManager.addMember(newMerc);
                         this.eventManager.publish('mercenary_hired', { mercenary: newMerc });
                     }
                 } else {
@@ -631,6 +638,7 @@ export class Game {
                         this.laneAssignmentManager.assignMercenaryToLane(newMerc);
                         this.entityManager.addEntity(newMerc);
                         this.playerGroup.addMember(newMerc);
+                        this.groupManager.addMember(newMerc);
                         this.eventManager.publish('mercenary_hired', { mercenary: newMerc });
                     }
                 } else {
@@ -656,6 +664,7 @@ export class Game {
                         this.laneAssignmentManager.assignMercenaryToLane(newMerc);
                         this.entityManager.addEntity(newMerc);
                         this.playerGroup.addMember(newMerc);
+                        this.groupManager.addMember(newMerc);
                         this.eventManager.publish('mercenary_hired', { mercenary: newMerc });
                     }
                 } else {
@@ -681,6 +690,7 @@ export class Game {
                         this.laneAssignmentManager.assignMercenaryToLane(newMerc);
                         this.entityManager.addEntity(newMerc);
                         this.playerGroup.addMember(newMerc);
+                        this.groupManager.addMember(newMerc);
                         this.eventManager.publish('mercenary_hired', { mercenary: newMerc });
                     }
                 } else {
@@ -706,6 +716,7 @@ export class Game {
                         this.laneAssignmentManager.assignMercenaryToLane(newMerc);
                         this.entityManager.addEntity(newMerc);
                         this.playerGroup.addMember(newMerc);
+                        this.groupManager.addMember(newMerc);
                         this.eventManager.publish('mercenary_hired', { mercenary: newMerc });
                     }
                 } else {
@@ -731,6 +742,7 @@ export class Game {
                         this.laneAssignmentManager.assignMercenaryToLane(newMerc);
                         this.entityManager.addEntity(newMerc);
                         this.playerGroup.addMember(newMerc);
+                        this.groupManager.addMember(newMerc);
                         this.eventManager.publish('mercenary_hired', { mercenary: newMerc });
                     }
                 } else {
@@ -756,6 +768,7 @@ export class Game {
                         this.laneAssignmentManager.assignMercenaryToLane(newMerc);
                         this.entityManager.addEntity(newMerc);
                         this.playerGroup.addMember(newMerc);
+                        this.groupManager.addMember(newMerc);
                         this.eventManager.publish('mercenary_hired', { mercenary: newMerc });
                     }
                 } else {

--- a/src/managers/groupManager.js
+++ b/src/managers/groupManager.js
@@ -1,0 +1,44 @@
+export class GroupManager {
+    constructor(eventManager = null, getEntityById = null) {
+        this.eventManager = eventManager;
+        this.getEntityById = getEntityById;
+        this.groups = {};
+        console.log('[GroupManager] Initialized');
+        if (this.eventManager) {
+            this.eventManager.subscribe('entity_removed', ({ victimId }) => {
+                this.removeMemberFromAll(victimId);
+            });
+        }
+    }
+
+    addMember(entity) {
+        if (!entity || !entity.groupId) return;
+        const groupId = entity.groupId;
+        if (!this.groups[groupId]) this.groups[groupId] = [];
+        if (!this.groups[groupId].includes(entity.id)) {
+            this.groups[groupId].push(entity.id);
+        }
+    }
+
+    removeMember(entity) {
+        if (!entity || !entity.groupId) return;
+        const groupId = entity.groupId;
+        if (this.groups[groupId]) {
+            this.groups[groupId] = this.groups[groupId].filter(id => id !== entity.id);
+        }
+    }
+
+    removeMemberFromAll(entityId) {
+        for (const groupId of Object.keys(this.groups)) {
+            this.groups[groupId] = this.groups[groupId].filter(id => id !== entityId);
+        }
+    }
+
+    getGroupMembers(groupId) {
+        const ids = this.groups[groupId] || [];
+        if (this.getEntityById) {
+            return ids.map(id => this.getEntityById(id)).filter(Boolean);
+        }
+        return ids;
+    }
+}

--- a/src/rendering/worldMapRenderManager.js
+++ b/src/rendering/worldMapRenderManager.js
@@ -1,0 +1,63 @@
+export class WorldmapRenderManager {
+    constructor(groupManager = null) {
+        this.groupManager = groupManager;
+        console.log('[WorldmapRenderManager] Initialized');
+    }
+
+    render(ctx, map, entities) {
+        this.renderMap(ctx, map);
+        this.renderEntities(ctx, entities);
+    }
+
+    renderMap(ctx, map) {
+        if (!map) return;
+        const worldTileImg = map.worldMapImage;
+        const seaTileImg = map.assets['sea-tile'];
+        if (!worldTileImg || !seaTileImg) return;
+
+        const worldWidth = map.worldWidth;
+        const worldHeight = map.worldHeight;
+        const tileSize = map.tileSize;
+
+        const seaPattern = ctx.createPattern(seaTileImg, 'repeat');
+        if (seaPattern) {
+            ctx.fillStyle = seaPattern;
+            ctx.fillRect(0, 0, worldWidth, worldHeight);
+        }
+
+        for (let y = tileSize; y < worldHeight - tileSize; y += tileSize) {
+            for (let x = tileSize; x < worldWidth - tileSize; x += tileSize) {
+                ctx.drawImage(worldTileImg, x, y, tileSize, tileSize);
+            }
+        }
+    }
+
+    renderEntities(ctx, entities) {
+        if (!entities) return;
+        for (const entity of entities) {
+            if (entity.image) {
+                ctx.drawImage(entity.image, entity.x, entity.y, entity.width || entity.tileSize, entity.height || entity.tileSize);
+            } else {
+                ctx.fillStyle = entity.color || 'red';
+                ctx.fillRect(entity.x, entity.y, entity.tileSize, entity.tileSize);
+            }
+
+            if (this.groupManager && entity.groupId) {
+                const members = this.groupManager.getGroupMembers(entity.groupId);
+                if (members) {
+                    const count = members.length;
+                    const textX = entity.x + (entity.tileSize || entity.width) / 2;
+                    const textY = entity.y + (entity.tileSize || entity.height) + 2;
+                    ctx.font = 'bold 12px Arial';
+                    ctx.fillStyle = 'white';
+                    ctx.textAlign = 'center';
+                    ctx.textBaseline = 'top';
+                    ctx.strokeStyle = 'black';
+                    ctx.lineWidth = 2;
+                    ctx.strokeText(count, textX, textY);
+                    ctx.fillText(count, textX, textY);
+                }
+            }
+        }
+    }
+}

--- a/src/worldEngine.js
+++ b/src/worldEngine.js
@@ -2,12 +2,14 @@ import { GridRenderer } from './renderers/gridRenderer.js';
 import { MovementEngine } from './engines/movementEngine.js';
 import { WorldTurnManager } from './managers/worldTurnManager.js';
 import { WalkManager } from './managers/walkManager.js';
+import { WorldmapRenderManager } from './rendering/worldMapRenderManager.js';
 
 export class WorldEngine {
-    constructor(game, assets, movementEngine = new MovementEngine({ tileSize: game.mapManager?.tileSize || 192 })) {
+    constructor(game, assets, movementEngine = new MovementEngine({ tileSize: game.mapManager?.tileSize || 192 }), renderManager = new WorldmapRenderManager()) {
         this.game = game;
         this.assets = assets;
         this.movementEngine = movementEngine;
+        this.renderManager = renderManager;
         this.worldMapImage = this.assets['world-tile'];
         // 전투 맵과 동일한 타일 크기를 사용해 월드맵 크기를 계산
         this.tileSize = this.game.mapManager?.tileSize || 192;
@@ -204,7 +206,11 @@ export class WorldEngine {
             baseCtx.save();
             baseCtx.scale(zoom, zoom);
             baseCtx.translate(-this.camera.x, -this.camera.y);
-            this._drawWorldMap(baseCtx);
+            if (this.renderManager && this.renderManager.renderMap) {
+                this.renderManager.renderMap(baseCtx, this);
+            } else {
+                this._drawWorldMap(baseCtx);
+            }
             baseCtx.restore();
         }
 
@@ -220,7 +226,11 @@ export class WorldEngine {
             entityCtx.save();
             entityCtx.scale(zoom, zoom);
             entityCtx.translate(-this.camera.x, -this.camera.y);
-            this._drawEntities(entityCtx);
+            if (this.renderManager && this.renderManager.renderEntities) {
+                this.renderManager.renderEntities(entityCtx, [this.player, ...this.monsters]);
+            } else {
+                this._drawEntities(entityCtx);
+            }
             entityCtx.restore();
         }
     }


### PR DESCRIPTION
## Summary
- create a `GroupManager` to track group membership
- add `WorldmapRenderManager` to draw entities with troop counts
- update `WorldEngine` to use the new render manager
- connect the new managers in `Game` and register group members

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ea5131d7083278c52784064b86a49