### PR TITLE
Add timer manager and integrate with micro engine

### DIFF
--- a/docs-managers-summary.md
+++ b/docs-managers-summary.md
@@ -69,5 +69,6 @@
 | `../systems/KnockbackEngine.js` | 공격 피격 시 대상에게 밀쳐내기 효과와 시각 연출을 적용합니다. |
 | `../micro/MicroEngine.js` | 미시 세계 전투와 아이템 상태 갱신을 담당하는 엔진입니다. |
 | `../micro/MicroTurnManager.js` | 모든 아이템의 쿨타임 감소를 전담합니다. |
+| `timerManager.js` | 제한 시간을 다루는 범용 타이머 매니저입니다. |
 
 추가 매니저가 도입되면 이 목록을 계속 확장해 주세요.

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -41,6 +41,7 @@ import { EntityManager } from './entityManager.js';
 import GuidelineLoader from './guidelineLoader.js';
 import { TooltipManager } from './tooltipManager.js';
 import { BattleManager } from './battleManager.js';
+import { TimerManager } from './timerManager.js';
 // DataRecorder is only needed in a Node.js environment so we lazy-load it
 let DataRecorder = null;
 if (typeof process !== 'undefined' && process.versions?.node) {
@@ -93,4 +94,5 @@ export {
     TooltipManager,
     DataRecorder,
     BattleManager,
+    TimerManager,
 };

--- a/src/managers/timerManager.js
+++ b/src/managers/timerManager.js
@@ -1,0 +1,53 @@
+export class TimerManager {
+    /**
+     * @param {number} duration - 타이머의 지속 시간 (초 단위)
+     * @param {function} onTimerEnd - 타이머가 종료됐을 때 실행할 콜백 함수
+     */
+    constructor(duration, onTimerEnd) {
+        this.initialDuration = duration;
+        this.onTimerEnd = onTimerEnd;
+        this.remainingTime = duration;
+        this.isRunning = false;
+        console.log(`[TimerManager] Initialized with duration: ${this.initialDuration}s`);
+    }
+
+    /** 타이머를 시작합니다. */
+    start() {
+        this.remainingTime = this.initialDuration;
+        this.isRunning = true;
+        console.log('[TimerManager] Timer started.');
+    }
+
+    /** 타이머를 정지합니다. */
+    stop() {
+        this.isRunning = false;
+        console.log('[TimerManager] Timer stopped.');
+    }
+
+    /**
+     * 매 프레임마다 호출되어 남은 시간을 갱신합니다.
+     * @param {number} deltaTime - 프레임 간의 시간 간격 (초 단위)
+     */
+    update(deltaTime) {
+        if (!this.isRunning) return;
+
+        this.remainingTime -= deltaTime;
+
+        if (this.remainingTime <= 0) {
+            this.remainingTime = 0;
+            this.isRunning = false;
+            console.log('[TimerManager] Time is up!');
+            if (this.onTimerEnd) {
+                this.onTimerEnd();
+            }
+        }
+    }
+
+    /**
+     * 남은 시간을 반환합니다.
+     * @returns {number} 남은 시간 (초 단위)
+     */
+    getRemainingTime() {
+        return this.remainingTime;
+    }
+}

--- a/src/micro/MicroEngine.js
+++ b/src/micro/MicroEngine.js
@@ -1,13 +1,36 @@
 import { MicroTurnManager } from './MicroTurnManager.js';
+import { TimerManager } from '../managers/timerManager.js';
 
 // src/micro/MicroEngine.js
 
 // MicroEngine handles the micro-world progression. It listens for combat events
 // and updates weapon experience and proficiency accordingly.
 export class MicroEngine {
-    constructor(eventManager) {
-        this.eventManager = eventManager;
+    constructor(arg1, arg2, arg3, arg4, arg5, arg6) {
+        if (arg2 === undefined && arg3 === undefined && arg4 === undefined) {
+            // legacy signature: constructor(eventManager)
+            this.eventManager = arg1;
+            this.ctx = null;
+            this.assets = null;
+            this.factory = null;
+            this.playerUnits = [];
+            this.enemyUnits = [];
+        } else {
+            // new signature: constructor(ctx, assets, eventManager, factory, playerUnits, enemyUnits)
+            this.ctx = arg1;
+            this.assets = arg2;
+            this.eventManager = arg3;
+            this.factory = arg4;
+            this.playerUnits = arg5 || [];
+            this.enemyUnits = arg6 || [];
+        }
+
         this.turnManager = new MicroTurnManager();
+
+        const BATTLE_DURATION = 30;
+        this.timerManager = new TimerManager(BATTLE_DURATION, () => this.endBattleByTimeout());
+        this.isRunning = false;
+        this.lastTime = 0;
 
         if (this.eventManager) {
             this.eventManager.subscribe('attack_landed', data => this.handleAttackLanded(data));
@@ -53,9 +76,81 @@ export class MicroEngine {
         return null;
     }
 
-    update(allItems) {
-        // 게임 루프로부터 전달된 아이템 목록을 TurnManager에 위임한다
-        this.turnManager.update(allItems);
-        // Additional micro-world systems can be ticked here.
+    start() {
+        this.isRunning = true;
+        this.timerManager.start();
+        this.gameLoop(0);
+        console.log('[MicroEngine] Started.');
+    }
+
+    stop() {
+        this.isRunning = false;
+        this.timerManager.stop();
+        console.log('[MicroEngine] Stopped.');
+    }
+
+    endBattleByTimeout() {
+        console.log('[MicroEngine] Battle ended due to timeout.');
+        this.stop();
+
+        const battleResult = {
+            winner: 'draw',
+            loser: 'draw',
+            survivors: {
+                player: this.playerUnits.filter(u => u.hp > 0),
+                enemy: this.enemyUnits.filter(u => u.hp > 0)
+            }
+        };
+
+        if (this.eventManager) {
+            this.eventManager.publish('battle_ended', battleResult);
+        }
+    }
+
+    gameLoop = (timestamp) => {
+        if (!this.isRunning) return;
+
+        const deltaTime = (timestamp - (this.lastTime || timestamp)) / 1000;
+        this.lastTime = timestamp;
+
+        this.update(deltaTime);
+        this.render();
+
+        requestAnimationFrame(this.gameLoop);
+    }
+
+    update(param) {
+        if (Array.isArray(param)) {
+            // 게임 루프로부터 전달된 아이템 목록을 TurnManager에 위임
+            this.turnManager.update(param);
+            return;
+        }
+
+        const deltaTime = param;
+        if (!this.isRunning) return;
+
+        this.timerManager.update(deltaTime);
+        // TODO: unit movement and combat updates go here
+    }
+
+    render() {
+        if (!this.ctx) return;
+        this.ctx.clearRect(0, 0, this.ctx.canvas.width, this.ctx.canvas.height);
+        // TODO: render units and background here
+        this.renderTimer();
+    }
+
+    renderTimer() {
+        if (!this.ctx) return;
+        const time = this.timerManager.getRemainingTime();
+        const minutes = Math.floor(time / 60);
+        const seconds = Math.floor(time % 60);
+        const timerText = `Time Left: ${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+
+        this.ctx.font = '24px Arial';
+        this.ctx.fillStyle = 'white';
+        this.ctx.textAlign = 'right';
+        this.ctx.textBaseline = 'top';
+        this.ctx.fillText(timerText, this.ctx.canvas.width - 20, 20);
     }
 }


### PR DESCRIPTION
## Summary
- create `TimerManager` for generic countdowns
- integrate timer into `MicroEngine` with backwards compatible constructor
- export new manager through `index.js`
- document the new manager in docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eac75c9008327ad14b165c5ec38d2