### PR TITLE
Add BattleResultManager and update group handling

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -38,6 +38,7 @@ import { MicroEngine } from './micro/MicroEngine.js';
 import { MicroCombatManager } from './micro/MicroCombatManager.js';
 import { MicroItemAIManager } from './managers/microItemAIManager.js';
 import { BattleManager } from './managers/battleManager.js';
+import { BattleResultManager } from './managers/battleResultManager.js';
 
 import { StatusEffectsManager } from './managers/statusEffectsManager.js';
 import { disarmWorkflow, armorBreakWorkflow } from './workflows.js';
@@ -145,6 +146,12 @@ export class Game {
         this.groupManager = new GroupManager(this.eventManager, this.entityManager.getEntityById.bind(this.entityManager));
         // CommanderManager 초기화
         this.commanderManager = new CommanderManager(this.groupManager);
+        // 전투 후 결과 처리를 담당하는 매니저
+        this.battleResultManager = new BattleResultManager(
+            this.eventManager,
+            this.groupManager,
+            this.entityManager
+        );
         // InputHandler를 생성할 때 game 객체(this)를 전달합니다.
         this.inputHandler = new InputHandler(this);
         this.combatLogManager = new CombatLogManager(this.eventManager);

--- a/src/managers/battleManager.js
+++ b/src/managers/battleManager.js
@@ -59,14 +59,7 @@ export class BattleManager {
             this.battleInstance = null;
         }
 
-        const { attacker, defender } = this.lastCombatants;
-        const losingLeader = result.loser === 'player' ? attacker : defender;
-
-        console.log(`[BattleManager] Removing defeated leader ${losingLeader.id} and their group.`);
-        this.groupManager.removeGroup(losingLeader.groupId);
-        this.entityManager.removeEntityById(losingLeader.id);
-
-        // TODO: update survivors of the winning group based on result.survivors
+        // 전투 결과 처리는 BattleResultManager가 담당한다
 
         this.game.showWorldMap();
         this.game.isPaused = false;

--- a/src/managers/battleResultManager.js
+++ b/src/managers/battleResultManager.js
@@ -1,0 +1,94 @@
+export class BattleResultManager {
+    constructor(eventManager, groupManager, entityManager) {
+        this.eventManager = eventManager;
+        this.groupManager = groupManager;
+        this.entityManager = entityManager;
+        this.lastCombatants = null;
+
+        console.log("[BattleResultManager] Initialized");
+        this.eventManager.subscribe('combat_started', ({ attacker, defender }) => {
+            this.lastCombatants = { attacker, defender };
+        });
+        this.eventManager.subscribe('battle_ended', (result) => {
+            this.processResult(result);
+        });
+    }
+
+    /**
+     * Process battle results and update world map state.
+     * @param {object} result - battle result emitted by MicroEngine
+     */
+    processResult(result) {
+        if (!this.lastCombatants) {
+            console.error("[BattleResultManager] 전투 참여자 정보가 없습니다.");
+            return;
+        }
+
+        const { attacker, defender } = this.lastCombatants;
+        const { winner, survivors } = result;
+
+        console.log(`[BattleResultManager] 전투 결과 처리 시작. 승자: ${winner}`);
+
+        // Build a set of survivor IDs
+        const survivorIds = new Set();
+        if (survivors) {
+            (survivors.player || []).forEach(u => survivorIds.add(u.id));
+            (survivors.enemy || []).forEach(u => survivorIds.add(u.id));
+        }
+
+        let losingCommander = null;
+        if (winner === 'player' || winner === 'draw') {
+            losingCommander = defender;
+        }
+        if (winner === 'enemy' || winner === 'draw') {
+            losingCommander = attacker;
+        }
+
+        if (winner !== 'draw' && losingCommander) {
+            this.removeDefeatedGroup(losingCommander, survivorIds);
+        } else {
+            this.updateGroupSurvivors(attacker.groupId, survivorIds);
+            this.updateGroupSurvivors(defender.groupId, survivorIds);
+        }
+
+        this.eventManager.publish('world_map_updated_after_battle');
+        this.lastCombatants = null;
+    }
+
+    /**
+     * Remove a defeated group or its fallen members.
+     * @param {Entity} commander - defeated commander
+     * @param {Set<string>} survivorIds - set of survivor entity IDs
+     */
+    removeDefeatedGroup(commander, survivorIds) {
+        const members = this.groupManager.getGroupMembers(commander.groupId);
+        if (survivorIds.has(commander.id)) {
+            console.log(`[BattleResultManager] ${commander.id} 부대 일부 생존. 생존자 업데이트.`);
+            this.updateGroupSurvivors(commander.groupId, survivorIds);
+        } else {
+            console.log(`[BattleResultManager] ${commander.id} 부대 전멸. 그룹 전체 제거.`);
+            this.groupManager.removeGroup(commander.groupId);
+            if (this.entityManager.removeEntityById) {
+                this.entityManager.removeEntityById(commander.id);
+            }
+        }
+    }
+
+    /**
+     * Update a group's members, keeping only survivors.
+     * @param {string} groupId - group ID to update
+     * @param {Set<string>} survivorIds - set of survivor IDs
+     */
+    updateGroupSurvivors(groupId, survivorIds) {
+        const members = this.groupManager.getGroupMembers(groupId);
+        if (!members) return;
+        for (const member of members) {
+            if (!survivorIds.has(member.id)) {
+                console.log(`[BattleResultManager] 사망자 처리: ${member.id}`);
+                if (this.groupManager.removeMemberFromGroup) {
+                    this.groupManager.removeMemberFromGroup(groupId, member.id);
+                }
+            }
+        }
+    }
+}

--- a/src/managers/entityManager.js
+++ b/src/managers/entityManager.js
@@ -51,4 +51,13 @@ export class EntityManager {
     getMonsters() {
         return this.monsters;
     }
+
+    removeEntityById(id) {
+        if (this.entities.has(id)) {
+            this.entities.delete(id);
+            if (this.eventManager) {
+                this.eventManager.publish('entity_removed', { victimId: id });
+            }
+        }
+    }
 }

--- a/src/managers/groupManager.js
+++ b/src/managers/groupManager.js
@@ -34,6 +34,36 @@ export class GroupManager {
         }
     }
 
+    /**
+     * Remove a specific member from a specific group.
+     * @param {string} groupId
+     * @param {string} memberId
+     */
+    removeMemberFromGroup(groupId, memberId) {
+        if (this.groups[groupId]) {
+            const idx = this.groups[groupId].indexOf(memberId);
+            if (idx !== -1) {
+                this.groups[groupId].splice(idx, 1);
+                console.log(`[GroupManager] 그룹 ${groupId}에서 멤버 ${memberId} 제거 완료.`);
+            }
+            if (this.groups[groupId].length === 0) {
+                console.log(`[GroupManager] 그룹 ${groupId}에 멤버가 없어 그룹을 해체합니다.`);
+                this.removeGroup(groupId);
+            }
+        }
+    }
+
+    /**
+     * Remove an entire group.
+     * @param {string} groupId
+     */
+    removeGroup(groupId) {
+        if (this.groups[groupId]) {
+            delete this.groups[groupId];
+            console.log(`[GroupManager] 그룹 ${groupId}가 완전히 제거되었습니다.`);
+        }
+    }
+
     getGroupMembers(groupId) {
         const ids = this.groups[groupId] || [];
         if (this.getEntityById) {


### PR DESCRIPTION
## Summary
- create `BattleResultManager` to manage battle outcome processing
- integrate it with `Game` initialization
- delegate world-map updates from `BattleManager` to the new manager
- extend `GroupManager` with member removal helpers
- expose `removeEntityById` in `EntityManager`

## Testing
- `npm test` *(fails to fully execute due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_685eb2f88ad0832780e028aff50484fe