### PR TITLE
Fix BattleManager eventManager initialization

### DIFF
--- a/src/managers/battleManager.js
+++ b/src/managers/battleManager.js
@@ -1,11 +1,17 @@
 // src/managers/battleManager.js
 
 import { MicroEngine } from '../micro/MicroEngine.js';
+import { EventManager } from './eventManager.js';
 
 export class BattleManager {
     constructor(game, eventManager, groupManager, entityManager, factory) {
         this.game = game;
-        this.eventManager = eventManager;
+        if (!eventManager || typeof eventManager.subscribe !== 'function') {
+            console.warn('[BattleManager] Provided eventManager is invalid; using a new instance');
+            this.eventManager = new EventManager();
+        } else {
+            this.eventManager = eventManager;
+        }
         this.groupManager = groupManager;
         this.entityManager = entityManager;
         this.factory = factory;


### PR DESCRIPTION
## Summary
- gracefully create a new EventManager when none is provided

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ec39582b083278006b065d1fd0152