### PR TITLE
Fix world map commander data

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -467,6 +467,11 @@ export class Game {
         });
         enemyFormationManager.apply(enemyFormationOrigin, monsterEntityMap);
 
+        // 월드맵에 첫 번째 몬스터를 지휘관으로 배치
+        if (this.worldEngine && monsterSquad[0]) {
+            this.worldEngine.addMonster(monsterSquad[0], 3, 2);
+        }
+
         // === 2. 플레이어 생성 ===
         let startPos;
         startPos = { x: this.mapManager.tileSize * 4, y: (this.mapManager.height * this.mapManager.tileSize) / 2 };

--- a/src/worldEngine.js
+++ b/src/worldEngine.js
@@ -30,24 +30,40 @@ export class WorldEngine {
         });
         // 플레이어 정보는 Game 초기화 이후 setPlayer()로 전달된다
         this.player = null;
-        this.monsters = [
-            {
-                tileX: 3,
-                tileY: 2,
-                x: this.tileSize * 3,
-                y: this.tileSize * 2,
-                width: this.tileSize,
-                height: this.tileSize,
-                image: this.assets['monster'],
-                troopSize: 10,
-                groupId: 'monster_party_1'
-            },
-        ];
+        // 월드맵에 표시될 몬스터 지휘관 목록
+        this.monsters = [];
         this.walkManager = new WalkManager();
         this.turnManager = new WorldTurnManager({
             movementEngine: this.movementEngine,
             entities: [...this.monsters]
         });
+    }
+
+    /**
+     * 월드맵에 몬스터 지휘관을 추가한다.
+     * @param {object} entity - 실제 몬스터 엔티티
+     * @param {number} tileX - 월드맵 타일 X 좌표
+     * @param {number} tileY - 월드맵 타일 Y 좌표
+     */
+    addMonster(entity, tileX, tileY) {
+        if (!entity) return;
+        const monster = {
+            id: entity.id,
+            entity,
+            groupId: entity.groupId,
+            tileX,
+            tileY,
+            x: tileX * this.tileSize,
+            y: tileY * this.tileSize,
+            width: this.tileSize,
+            height: this.tileSize,
+            image: entity.image || this.assets['monster'],
+            isActive: true,
+        };
+        this.monsters.push(monster);
+        if (this.turnManager) {
+            this.turnManager.entities = [this.player, ...this.monsters];
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- remove placeholder world map monster and add command for hooking real monster groups
- create `addMonster` method in `WorldEngine`
- register real monster commander in world map during setup

## Testing
- `npm test` *(fails: TensorFlow initialization and missing images)*

------
https://chatgpt.com/codex/tasks/task_e_685ecbc600108327b468a64e0d96af7d