### PR TITLE
Improve world map interactions

### DIFF
--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -77,8 +77,11 @@ export class UIManager {
         this.troopDetailsList = document.getElementById('troop-details-list');
         this.closeCommanderInfo = document.getElementById('close-commander-info');
 
-        // [추가] 월드맵 캔버스에 클릭 이벤트 리스너를 등록합니다.
-        this.canvas = document.getElementById('map-base-canvas');
+        // [수정] 가장 위에 위치한 캔버스(weather-canvas)에 클릭 이벤트를 연결합니다.
+        // 다른 캔버스가 위에 겹쳐 있을 경우에도 클릭을 정확히 감지하기 위함입니다.
+        this.canvas = document.getElementById('weather-canvas') ||
+                      document.getElementById('entity-canvas') ||
+                      document.getElementById('map-base-canvas');
         if (this.canvas) {
             this.canvas.addEventListener('click', this.handleCanvasClick.bind(this));
         }

--- a/src/managers/walkManager.js
+++ b/src/managers/walkManager.js
@@ -8,17 +8,20 @@ export class WalkManager {
      * @param {object} targetEntity - 목표 엔티티 (예: player)
      * @returns {{x: number, y: number}} 다음 타일 좌표
      */
-    getNextStep(startEntity, targetEntity) {
+    getNextStep(startEntity, targetEntity, steps = 1) {
         const nextTile = { x: startEntity.tileX, y: startEntity.tileY };
-        const dx = targetEntity.tileX - startEntity.tileX;
-        const dy = targetEntity.tileY - startEntity.tileY;
 
-        if (Math.abs(dx) > Math.abs(dy)) {
-            if (dx > 0) nextTile.x++;
-            else if (dx < 0) nextTile.x--;
-        } else {
-            if (dy > 0) nextTile.y++;
-            else if (dy < 0) nextTile.y--;
+        for (let i = 0; i < steps; i++) {
+            const dx = targetEntity.tileX - nextTile.x;
+            const dy = targetEntity.tileY - nextTile.y;
+
+            if (Math.abs(dx) > Math.abs(dy)) {
+                if (dx > 0) nextTile.x++;
+                else if (dx < 0) nextTile.x--;
+            } else {
+                if (dy > 0) nextTile.y++;
+                else if (dy < 0) nextTile.y--;
+            }
         }
 
         return nextTile;

--- a/src/worldEngine.js
+++ b/src/worldEngine.js
@@ -150,7 +150,7 @@ export class WorldEngine {
         for (const monster of this.monsters) {
             if (!monster || this.movementEngine.isMoving(monster)) continue;
 
-            const nextStep = this.walkManager.getNextStep(monster, this.player);
+            const nextStep = this.walkManager.getNextStep(monster, this.player, 2);
 
             if (nextStep.x >= 0 && nextStep.x < this.worldWidth / this.tileSize &&
                 nextStep.y >= 0 && nextStep.y < this.worldHeight / this.tileSize) {

--- a/tests/integration/worldFlow.integration.test.js
+++ b/tests/integration/worldFlow.integration.test.js
@@ -63,10 +63,10 @@ describe('World-Battle Flow Integration', () => {
       microEngine.update(31); // 타이머 만료로 전투 종료
     });
 
-    // --- 적의 턴: 플레이어에게 한 칸 다가옴 ---
+    // --- 적의 턴: 플레이어에게 두 칸 다가옴 ---
     world.turnManager.currentTurn = 'ENEMY';
     world.update(1);
-    assert.strictEqual(enemyCommander.tileX, 3);
+    assert.strictEqual(enemyCommander.tileX, 2);
 
     // --- 플레이어 턴: 이동하여 충돌 유발 ---
     game.inputHandler.keysPressed['ArrowRight'] = true;


### PR DESCRIPTION
## Summary
- attach world map click handler to the top canvas so commanders always show info
- allow WalkManager to calculate multiple tile steps
- let monsters move two tiles per world turn
- update integration test for new monster speed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ed191fd148327ab17e5f9592b5239