### PR TITLE
Add battle prep overlay and commander slot

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
         <canvas id="weather-canvas" class="game-layer"></canvas>
     </div>
     <canvas id="minimap-canvas" class="ui-frame"></canvas>
+    <div id="prep-screen" class="prep-screen"></div>
 
     <canvas id="battleCanvas" width="1600" height="900" style="display: none; border: 1px solid red;"></canvas>
 
@@ -109,7 +110,7 @@
         <h2 class="window-header">부대 편성</h2>
         <div class="squad-content"></div>
         <div id="formation-grid" class="formation-grid"></div>
-        <button id="confirm-formation-btn" class="confirm-btn">전투 시작</button>
+        <button id="confirm-formation-btn" class="confirm-btn">준비 완료</button>
     </div>
 
     <!-- 캐릭터 스탯 패널 템플릿 -->

--- a/src/game.js
+++ b/src/game.js
@@ -847,6 +847,11 @@ export class Game {
 
         this.setupEventListeners(assets, canvas);
         this.showWorldMap();
+
+        const prepScreen = document.getElementById('prep-screen');
+        if (prepScreen) prepScreen.classList.remove('hidden');
+        this.uiManager.showPanel('squad-management-ui');
+        this.gameState.currentState = 'PREPARE';
         this.gameLoop = new GameLoop(this.update, this.render);
         this.gameLoop.start();
     }
@@ -869,7 +874,13 @@ export class Game {
             const entityMap = { [gameState.player.id]: gameState.player };
             this.mercenaryManager.mercenaries.forEach(m => { entityMap[m.id] = m; });
             this.formationManager.apply(origin, entityMap);
-            gameState.currentState = 'COMBAT';
+            if (gameState.currentState === 'PREPARE') {
+                const prepScreen = document.getElementById('prep-screen');
+                if (prepScreen) prepScreen.classList.add('hidden');
+                gameState.currentState = 'WORLD';
+            } else {
+                gameState.currentState = 'COMBAT';
+            }
         });
 
         eventManager.subscribe('end_combat', (result) => {

--- a/src/managers/squadManager.js
+++ b/src/managers/squadManager.js
@@ -9,7 +9,8 @@ export class SquadManager {
             this.squads[`squad_${i}`] = {
                 name: `${i}\uBD84\uB300`,
                 members: new Set(),
-                strategy: i === 1 ? STRATEGY.AGGRESSIVE : STRATEGY.DEFENSIVE
+                strategy: i === 1 ? STRATEGY.AGGRESSIVE : STRATEGY.DEFENSIVE,
+                commanderId: null
             };
         }
         this.unassignedMercs = new Set(
@@ -19,6 +20,7 @@ export class SquadManager {
             this.eventManager.subscribe('squad_assign_request', d => this.handleSquadAssignment(d));
             this.eventManager.subscribe('squad_strategy_change_request', d => this.setSquadStrategy(d));
             this.eventManager.subscribe('mercenary_hired', ({ mercenary }) => this.registerMercenary(mercenary));
+            this.eventManager.subscribe('commander_assign_request', d => this.setCommander(d));
         }
     }
 
@@ -31,6 +33,7 @@ export class SquadManager {
     handleSquadAssignment({ mercId, toSquadId }) {
         for (const squad of Object.values(this.squads)) {
             squad.members.delete(mercId);
+            if (squad.commanderId === mercId) squad.commanderId = null;
         }
         this.unassignedMercs.delete(mercId);
         if (toSquadId && this.squads[toSquadId]) {
@@ -44,6 +47,19 @@ export class SquadManager {
             if (merc) merc.squadId = null;
             console.log(`용병 ${mercId}를 미편성 상태로 변경했습니다.`);
         }
+        this.eventManager?.publish('squad_data_changed', { squads: this.squads });
+    }
+
+    setCommander({ mercId, squadId }) {
+        if (!this.squads[squadId]) return;
+        // remove merc from other commanders
+        for (const s of Object.values(this.squads)) {
+            if (s.commanderId === mercId) s.commanderId = null;
+        }
+        this.squads[squadId].commanderId = mercId;
+        const merc = this.mercenaryManager.getMercenaries().find(m => m.id === mercId);
+        if (merc) merc.squadId = squadId;
+        this.squads[squadId].members.add(mercId);
         this.eventManager?.publish('squad_data_changed', { squads: this.squads });
     }
 

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -1051,7 +1051,30 @@ export class UIManager {
             const panel = document.createElement('div');
             panel.className = 'squad-panel';
             panel.dataset.squadId = sq.id === 'unassigned' ? '' : sq.id;
-            panel.textContent = sq.name;
+
+            const nameLabel = document.createElement('span');
+            nameLabel.textContent = sq.name;
+            panel.appendChild(nameLabel);
+
+            if (sq.id !== 'unassigned') {
+                const commanderSlot = document.createElement('div');
+                commanderSlot.className = 'commander-slot';
+                commanderSlot.dataset.squadId = sq.id;
+                commanderSlot.addEventListener('dragover', e => e.preventDefault());
+                commanderSlot.addEventListener('drop', e => {
+                    e.preventDefault();
+                    const mercId = e.dataTransfer.getData('text/plain');
+                    this.eventManager?.publish('commander_assign_request', { mercId, squadId: sq.id });
+                });
+                const cmdId = this.squadManager?.getSquads?.()[sq.id]?.commanderId;
+                if (cmdId) {
+                    const portrait = document.createElement('div');
+                    portrait.className = 'merc-portrait';
+                    portrait.textContent = cmdId;
+                    commanderSlot.appendChild(portrait);
+                }
+                panel.appendChild(commanderSlot);
+            }
             if (sq.id !== 'unassigned') {
                 panel.draggable = true;
                 panel.addEventListener('dragstart', e => {
@@ -1109,7 +1132,10 @@ export class UIManager {
             });
             const squadId = merc.squadId || 'unassigned';
             const parent = panelMap[squadId] || content;
-            parent.appendChild(el);
+            const squadInfo = this.squadManager?.getSquads?.()[squadId];
+            if (!squadInfo || squadInfo.commanderId !== merc.id) {
+                parent.appendChild(el);
+            }
         });
 
         const grid = document.getElementById('formation-grid');

--- a/style.css
+++ b/style.css
@@ -523,6 +523,8 @@ body, html {
     margin: 4px;
     min-height: 64px;
     background-color: rgba(0,0,0,0.3);
+    display: flex;
+    align-items: center;
 }
 
 .merc-portrait {
@@ -536,6 +538,16 @@ body, html {
     align-items: center;
     justify-content: center;
     font-size: 12px;
+}
+
+.commander-slot {
+    border: 2px dashed #777;
+    width: 36px;
+    height: 36px;
+    margin-right: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 
@@ -602,3 +614,15 @@ body, html {
 }
 .details-list li:last-child { border-bottom: none; }
 .details-list li strong { text-transform: capitalize; }
+
+/* Battle preparation overlay */
+.prep-screen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: black;
+    z-index: 150;
+}
+.prep-screen.hidden { display: none; }


### PR DESCRIPTION
## Summary
- introduce black prep-screen overlay during initial preparation phase
- show '준비 완료' button and horizontal squad layout
- add commander slot per squad and allow assignment
- hide prep screen after formations are confirmed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ee8a14ec08327bbb4a12af5b91e6e