### PR TITLE
Add battle preparation state and UI templates

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -28,6 +28,7 @@ import { NarrativeManager } from './managers/narrativeManager.js';
 import { TurnManager } from './managers/turnManager.js';
 import { EntityManager } from './managers/entityManager.js';
 import { KnockbackEngine } from './systems/KnockbackEngine.js';
+import { BattlePreparationState } from './states/BattlePreparationState.js';
 import { SupportEngine } from './systems/SupportEngine.js';
 import { SKILLS } from './data/skills.js';
 import { EFFECTS } from './data/effects.js';

--- a/src/states/BattlePreparationState.js
+++ b/src/states/BattlePreparationState.js
@@ -1,0 +1,14 @@
+import { createSquadManagementUI } from '../ui/squad-management-ui/squad-management-ui.js';
+
+export class BattlePreparationState extends Phaser.State {
+    create() {
+        // 1. 검은색 배경 설정
+        this.game.stage.backgroundColor = '#000000';
+
+        // 2. 부대 편성 UI 생성 및 표시
+        this.squadManagementUI = createSquadManagementUI(this.game);
+        this.game.world.add(this.squadManagementUI);
+
+        console.log("전투 준비 페이즈 시작");
+    }
+}

--- a/src/ui/squad-management-ui/squad-management-ui.css
+++ b/src/ui/squad-management-ui/squad-management-ui.css
@@ -1,0 +1,43 @@
+/* 부대 슬롯 컨테이너 */
+.unit-slots {
+    display: flex;
+    align-items: center; /* 슬롯들을 세로 중앙 정렬 */
+    margin-bottom: 10px;
+}
+
+/* 지휘관 슬롯 */
+.commander-slot {
+    width: 60px;
+    height: 60px;
+    border: 2px solid gold; /* 금색 테두리로 특별하게 표시 */
+    margin-right: 15px; /* 대원 슬롯과의 간격 */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #444;
+}
+
+/* 대원 슬롯들을 감싸는 컨테이너 */
+.member-slots {
+    display: flex;
+    flex-direction: row; /* 대원들을 가로로 나열 */
+    gap: 5px; /* 슬롯 사이의 간격 */
+}
+
+/* 개별 대원 슬롯 (기존 스타일 유지 또는 필요시 수정) */
+.unit-slot {
+    width: 50px;
+    height: 50px;
+    border: 1px solid #ccc;
+    background-color: #333;
+}
+
+/* 준비 완료 버튼 */
+#ready-button {
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+    padding: 10px 20px;
+    font-size: 16px;
+    cursor: pointer;
+}

--- a/src/ui/squad-management-ui/squad-management-ui.html
+++ b/src/ui/squad-management-ui/squad-management-ui.html
@@ -1,0 +1,20 @@
+<div id="squad-management-container">
+    <h2>부대 편성</h2>
+    <div class="squad-list">
+        <div class="squad">
+            <h3>1부대</h3>
+            <div class="unit-slots">
+                <div class="commander-slot" data-unit-id="null">
+                    <span>지휘관</span>
+                </div>
+                <div class="member-slots">
+                    <div class="unit-slot" data-unit-id="null"></div>
+                    <div class="unit-slot" data-unit-id="null"></div>
+                    <div class="unit-slot" data-unit-id="null"></div>
+                    </div>
+            </div>
+        </div>
+        </div>
+
+    <button id="ready-button">준비 완료</button>
+</div>

--- a/src/ui/squad-management-ui/squad-management-ui.js
+++ b/src/ui/squad-management-ui/squad-management-ui.js
@@ -1,0 +1,46 @@
+export function createSquadManagementUI(game) {
+    // ... (기존 UI 생성 코드)
+
+    // --- 기존 코드 아래에 다음 내용을 추가 ---
+
+    // 1. 준비 완료 버튼 이벤트 리스너 추가
+    const readyButton = document.getElementById('ready-button');
+    readyButton.addEventListener('click', () => {
+        console.log("부대 편성 완료! 전투를 시작합니다.");
+        // 여기서 실제 전투 상태로 전환하는 로직을 호출합니다.
+        // 예: game.state.start('Battle');
+        
+        // UI 숨기기 또는 제거
+        const uiContainer = document.getElementById('squad-management-container');
+        if (uiContainer) {
+            uiContainer.style.display = 'none';
+        }
+    });
+
+    // 2. 지휘관 및 대원 슬롯 드래그 앤 드롭 로직 (예시)
+    // 이 부분은 프로젝트의 기존 드래그 앤 드롭 구현 방식에 맞춰 수정해야 합니다.
+    const allSlots = document.querySelectorAll('.commander-slot, .unit-slot');
+    allSlots.forEach(slot => {
+        slot.addEventListener('drop', (event) => {
+            event.preventDefault();
+            const mercenaryId = event.dataTransfer.getData('text/plain');
+            
+            // 슬롯에 용병 정보 업데이트
+            slot.dataset.unitId = mercenaryId;
+            slot.textContent = `용병 ${mercenaryId}`; // 또는 용병 이미지 표시
+            
+            if (slot.classList.contains('commander-slot')) {
+                console.log(`${mercenaryId}가 지휘관으로 임명되었습니다.`);
+            } else {
+                console.log(`${mercenaryId}가 대원으로 배치되었습니다.`);
+            }
+        });
+
+        slot.addEventListener('dragover', (event) => {
+            event.preventDefault();
+        });
+    });
+
+
+    return uiGroup; // PIXI.DisplayObject 또는 Phaser.Group 등 UI 객체 반환
+}


### PR DESCRIPTION
## Summary
- add a new `BattlePreparationState` with placeholder Phaser logic
- import the state in `game.js`
- create simple squad-management UI templates (HTML, CSS and JS)

## Testing
- `npm test` *(fails: TensorFlow loader could not initialize, tests did not fully run)*

------
https://chatgpt.com/codex/tasks/task_e_685f8bb96034832792349473330a4328