### PR TITLE
Handle victory state

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -877,6 +877,7 @@ export class Game {
             gameState.currentState = 'WORLD';
             if (result.outcome === 'victory') {
                 this.worldEngine.monsters = this.worldEngine.monsters.filter(m => m.isActive === false);
+                alert('Victory!');
             }
             this.worldEngine.monsters.forEach(m => m.isActive = true);
         });
@@ -1018,6 +1019,14 @@ export class Game {
                 corpse.bobbingAmount = 0;
                 corpse.baseY = victim.y;
                 this.itemManager.addItem(corpse);
+            }
+
+            if (victim.unitType === 'monster') {
+                const remaining = this.monsterManager.monsters.filter(m => m.hp > 0 && !m.isDying);
+                if (remaining.length === 0) {
+                    this.eventManager.publish('log', { message: 'victory', color: 'green' });
+                    this.eventManager.publish('end_combat', { outcome: 'victory' });
+                }
             }
         });
 


### PR DESCRIPTION
## Summary
- show `Victory!` alert when combat ends in a win
- return to world map once all monsters are defeated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fd07c5704832782a8a11a81c72aae