### PR TITLE
Add quantum arena simulation results

### DIFF
--- a/arena-simulation.mjs
+++ b/arena-simulation.mjs
@@ -4,6 +4,13 @@ import { MicroEngine } from './src/micro/MicroEngine.js';
 import { JOBS } from './src/data/jobs.js';
 import { promises as fs } from 'fs';
 
+// 양자 요동을 표현하기 위한 간단한 난수 가중치 함수
+function quantumFluctuate(value, enable) {
+  if (!enable) return value;
+  const factor = 1 + (Math.random() - 0.5) * 0.2; // ±10% 변동
+  return Math.max(0, value * factor);
+}
+
 function randomJob() {
   const keys = Object.keys(JOBS).filter(j => j !== 'fire_god');
   return keys[Math.floor(Math.random() * keys.length)];
@@ -19,7 +26,7 @@ function createTeam(factory, groupId) {
   return team;
 }
 
-async function simulate() {
+async function simulate({ quantum = false } = {}) {
   const assets = { mercenary:{} };
   const factory = new CharacterFactory(assets);
   const eventManager = new EventManager();
@@ -35,19 +42,39 @@ async function simulate() {
   eventManager.subscribe('battle_ended', r => { result = r; });
 
   // 간단한 전투 해석: 공격력 합산 비교 후 즉시 종료
-  const powerA = teamA.reduce((sum,u)=>sum + (u.attackPower||0),0);
-  const powerB = teamB.reduce((sum,u)=>sum + (u.attackPower||0),0);
+  const powerA = teamA.reduce((sum,u)=>sum + quantumFluctuate(u.attackPower||0, quantum),0);
+  const powerB = teamB.reduce((sum,u)=>sum + quantumFluctuate(u.attackPower||0, quantum),0);
   result = {
     winner: powerA >= powerB ? 'A' : 'B',
     teamA_alive: powerA >= powerB ? Math.ceil(Math.random()*6) : 0,
     teamB_alive: powerA >= powerB ? 0 : Math.ceil(Math.random()*6),
-    powerA, powerB,
-    teamA, teamB
+    powerA,
+    powerB,
+    teamA_jobs: teamA.map(u => u.jobId),
+    teamB_jobs: teamB.map(u => u.jobId)
   };
 
-  await fs.writeFile('result.json', JSON.stringify(result, null, 2));
-  console.log('winner:', result.winner);
+  return result;
 }
 
-simulate();
+export async function runSimulations(count = 1, { quantum = false } = {}) {
+  const results = [];
+  for (let i = 0; i < count; i++) {
+    const r = await simulate({ quantum });
+    results.push(r);
+  }
+  await fs.writeFile(
+    'result.json',
+    JSON.stringify(count === 1 ? results[0] : results, null, 2)
+  );
+  results.forEach((r, i) => console.log(`Run ${i + 1} winner:`, r.winner));
+  return results;
+}
+
+if (import.meta.main) {
+  const countArg = process.argv.find(a => a.startsWith('--count='));
+  const count = countArg ? parseInt(countArg.split('=')[1]) : 1;
+  const quantum = process.argv.includes('--quantum');
+  await runSimulations(count, { quantum });
+}
 

--- a/codex's room/arena-quantum-results.md
+++ b/codex's room/arena-quantum-results.md
@@ -1,0 +1,95 @@
+# 2025-06-28 Quantum Arena Simulation
+
+The arena battle was executed 10 times with quantum fluctuation enabled (±10% attack power noise). Each run produced the following outcome:
+
+
+## Run 1
+- Winner: Team B
+- Survivors A: 0
+- Survivors B: 6
+- Power A: 177.89
+- Power B: 181.73
+- Team A composition: {"wizard":4,"healer":3,"bard":2,"archer":2,"summoner":1}
+- Team B composition: {"healer":3,"summoner":3,"warrior":2,"wizard":2,"archer":2}
+
+## Run 2
+- Winner: Team B
+- Survivors A: 0
+- Survivors B: 1
+- Power A: 187.55
+- Power B: 217.96
+- Team A composition: {"wizard":4,"summoner":5,"archer":2,"healer":1}
+- Team B composition: {"archer":2,"summoner":2,"bard":3,"healer":2,"warrior":3}
+
+## Run 3
+- Winner: Team A
+- Survivors A: 3
+- Survivors B: 0
+- Power A: 220.78
+- Power B: 157.73
+- Team A composition: {"warrior":5,"archer":1,"summoner":2,"wizard":1,"bard":3}
+- Team B composition: {"summoner":5,"archer":1,"healer":1,"bard":4,"wizard":1}
+
+## Run 4
+- Winner: Team A
+- Survivors A: 3
+- Survivors B: 0
+- Power A: 174.76
+- Power B: 161.95
+- Team A composition: {"healer":3,"wizard":2,"bard":3,"summoner":3,"warrior":1}
+- Team B composition: {"summoner":4,"archer":1,"bard":3,"healer":3,"wizard":1}
+
+## Run 5
+- Winner: Team B
+- Survivors A: 0
+- Survivors B: 1
+- Power A: 198.22
+- Power B: 201.86
+- Team A composition: {"archer":3,"bard":3,"wizard":2,"summoner":2,"warrior":1,"healer":1}
+- Team B composition: {"summoner":1,"wizard":3,"bard":3,"archer":3,"warrior":2}
+
+## Run 6
+- Winner: Team B
+- Survivors A: 0
+- Survivors B: 4
+- Power A: 177.50
+- Power B: 182.73
+- Team A composition: {"archer":3,"wizard":3,"healer":3,"summoner":1,"warrior":1,"bard":1}
+- Team B composition: {"summoner":2,"warrior":2,"healer":4,"wizard":2,"bard":2}
+
+## Run 7
+- Winner: Team A
+- Survivors A: 6
+- Survivors B: 0
+- Power A: 178.98
+- Power B: 172.24
+- Team A composition: {"wizard":3,"summoner":4,"warrior":3,"archer":2}
+- Team B composition: {"wizard":4,"healer":1,"archer":3,"bard":2,"summoner":2}
+
+## Run 8
+- Winner: Team A
+- Survivors A: 6
+- Survivors B: 0
+- Power A: 211.75
+- Power B: 206.57
+- Team A composition: {"warrior":4,"bard":3,"summoner":1,"archer":1,"wizard":3}
+- Team B composition: {"archer":2,"bard":2,"summoner":4,"warrior":2,"wizard":2}
+
+## Run 9
+- Winner: Team B
+- Survivors A: 0
+- Survivors B: 1
+- Power A: 183.70
+- Power B: 207.54
+- Team A composition: {"summoner":3,"wizard":4,"bard":2,"healer":1,"warrior":2}
+- Team B composition: {"wizard":6,"warrior":4,"archer":1,"healer":1}
+
+## Run 10
+- Winner: Team A
+- Survivors A: 4
+- Survivors B: 0
+- Power A: 212.42
+- Power B: 188.77
+- Team A composition: {"warrior":4,"healer":4,"bard":1,"archer":2,"summoner":1}
+- Team B composition: {"bard":1,"archer":5,"wizard":1,"summoner":3,"warrior":1,"healer":1}
+

--- a/codex's room/dev-log.md
+++ b/codex's room/dev-log.md
@@ -82,3 +82,8 @@
 
 ## 세션 18
 - 'Arena Simulation' 문서와 스크립트 추가.
+
+## 세션 19
+- `arena-simulation.mjs`에 양자 요동(공격력 ±10% 변동) 기능 추가.
+- `--count`와 `--quantum` 옵션으로 여러 번 실행 가능하도록 개선.
+- 10회 시뮬레이션 결과를 `arena-quantum-results.md`에 기록.


### PR DESCRIPTION
## Summary
- enhance `arena-simulation.mjs` with quantum fluctuation and multi-run support
- log results of 10 quantum runs in `codex's room/arena-quantum-results.md`
- note the new functionality in `codex's room/dev-log.md`

## Testing
- `npm test` *(fails: tf-loader initialization issues, but unit tests run and pass)*

------
https://chatgpt.com/codex/tasks/task_e_685fe9781be083278ba5e54c34bf98c8