### PR TITLE
Implement basic arena spectator mode

### DIFF
--- a/src/arena/Unit.js
+++ b/src/arena/Unit.js
@@ -5,11 +5,62 @@ class Unit {
         this.mbti = mbti;
         this.x = position.x;
         this.y = position.y;
+        this.radius = 20;
         this.hp = 100;
+        this.speed = 40; // px per second
+        this.attackRange = 25;
+        this.attackCooldown = 0;
     }
 
     isAlive() {
         return this.hp > 0;
+    }
+
+    update(deltaTime, units) {
+        if (!this.isAlive()) return;
+
+        if (this.attackCooldown > 0) {
+            this.attackCooldown -= deltaTime;
+        }
+
+        const enemies = units.filter(u => u.team !== this.team && u.isAlive());
+        if (enemies.length === 0) return;
+
+        let nearest = enemies[0];
+        let minDist = Number.MAX_VALUE;
+        for (const e of enemies) {
+            const dx = e.x - this.x;
+            const dy = e.y - this.y;
+            const dist = Math.hypot(dx, dy);
+            if (dist < minDist) {
+                minDist = dist;
+                nearest = e;
+            }
+        }
+
+        if (minDist > this.attackRange) {
+            const dirX = (nearest.x - this.x) / minDist;
+            const dirY = (nearest.y - this.y) / minDist;
+            this.x += dirX * this.speed * deltaTime;
+            this.y += dirY * this.speed * deltaTime;
+        } else if (this.attackCooldown <= 0) {
+            nearest.hp -= 10;
+            this.attackCooldown = 1; // 1 second cooldown
+        }
+    }
+
+    render(ctx) {
+        ctx.save();
+        ctx.fillStyle = this.team === 'A' ? 'red' : 'blue';
+        ctx.beginPath();
+        ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.fillStyle = 'white';
+        ctx.font = '12px Arial';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(Math.max(0, Math.floor(this.hp)), this.x, this.y);
+        ctx.restore();
     }
 }
 

--- a/src/arena/arenaManager.js
+++ b/src/arena/arenaManager.js
@@ -14,11 +14,15 @@ class ArenaManager {
         this.isActive = true;
         this.game.clearAllUnits();
         console.log("\u2694\ufe0f \uc544\ub808\ub098\uc5d0 \uc624\uc2e0 \uac83\uc744 \ud658\uc601\ud569\ub2c8\ub2e4! AI \uc790\ub3d9 \ub300\ub825\uc744 \uc2dc\uc791\ud569\ub2c8\ub2e4.");
+        this.game.showBattleMap();
+        this.game.gameState.currentState = 'ARENA';
         this.nextRound();
     }
 
     stop() {
         this.isActive = false;
+        this.game.showWorldMap();
+        this.game.gameState.currentState = 'WORLD';
         console.log(`\ud83d\udc4b \uc544\ub808\ub098\ub97c \ub5a0\ub0a0\uae4c. \ucd1d ${this.roundCount} \ub77c\uc6b4\ub4dc\uc758 \ub370\uc774\ud130\uac00 \uae30\ub85d\ub418\uc5c8\uc2b5\ub2c8\ub2e4.`);
     }
 
@@ -46,8 +50,13 @@ class ArenaManager {
         }
     }
 
-    update() {
+    update(deltaTime) {
         if (!this.isActive) return;
+
+        for (const unit of this.game.units) {
+            unit.update(deltaTime, this.game.units);
+        }
+
         const teamA_units = this.game.units.filter(u => u.team === 'A' && u.isAlive());
         const teamB_units = this.game.units.filter(u => u.team === 'B' && u.isAlive());
         let winner = null;
@@ -60,6 +69,14 @@ class ArenaManager {
             console.log(`\ud83c\udfc6 \ub77c\uc6b4\ub4dc ${this.roundCount} \uc885\ub8cc! \uc2b9\uc790: \ud300 ${winner}`);
             this.recordRoundResult(winner);
             this.nextRound();
+        }
+    }
+
+    render(ctx) {
+        if (!this.isActive) return;
+        ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+        for (const unit of this.game.units) {
+            unit.render(ctx);
         }
     }
 

--- a/src/game.js
+++ b/src/game.js
@@ -1260,14 +1260,14 @@ export class Game {
         weatherLayer.addEventListener('mousedown', (e) => {
             if (this.gameState.currentState === 'WORLD') {
                 this.worldEngine.startDrag(e.clientX, e.clientY);
-            } else if (this.gameState.currentState === 'COMBAT') {
+            } else if (this.gameState.currentState === 'COMBAT' || this.gameState.currentState === 'ARENA') {
                 this.startDragCamera(e.clientX, e.clientY);
             }
         });
         weatherLayer.addEventListener('mousemove', (e) => {
             if (this.gameState.currentState === 'WORLD') {
                 this.worldEngine.drag(e.clientX, e.clientY);
-            } else if (this.gameState.currentState === 'COMBAT') {
+            } else if (this.gameState.currentState === 'COMBAT' || this.gameState.currentState === 'ARENA') {
                 this.dragCamera(e.clientX, e.clientY);
             }
         });
@@ -1275,7 +1275,7 @@ export class Game {
             weatherLayer.addEventListener(ev, () => {
                 if (this.gameState.currentState === 'WORLD') {
                     this.worldEngine.endDrag();
-                } else if (this.gameState.currentState === 'COMBAT') {
+                } else if (this.gameState.currentState === 'COMBAT' || this.gameState.currentState === 'ARENA') {
                     this.endDragCamera();
                 }
             });
@@ -1306,13 +1306,16 @@ export class Game {
             return;
         } else if (this.gameState.currentState === 'FORMATION_SETUP') {
             return;
-        } else if (this.gameState.currentState !== 'COMBAT') {
+        } else if (this.gameState.currentState !== 'COMBAT' && this.gameState.currentState !== 'ARENA') {
             return;
         }
 
-        this.combatEngine.update(deltaTime);
+        if (this.gameState.currentState === 'COMBAT') {
+            this.combatEngine.update(deltaTime);
+        }
+
         if (this.arenaManager && this.arenaManager.isActive) {
-            this.arenaManager.update();
+            this.arenaManager.update(deltaTime);
         }
     }
     render = () => {
@@ -1325,6 +1328,8 @@ export class Game {
             );
         } else if (this.gameState.currentState === "COMBAT") {
             this.combatEngine.render();
+        } else if (this.gameState.currentState === "ARENA") {
+            this.arenaManager.render(this.battleCtx);
         }
         if (this.uiManager) this.uiManager.updateUI(this.gameState);
     }


### PR DESCRIPTION
## Summary
- add simple combat behavior and rendering for arena units
- manage arena lifecycle and state transitions in `ArenaManager`
- support new `ARENA` state in `Game` update/render logic

## Testing
- `npm test` *(fails: TensorFlow loader requires window)*

------
https://chatgpt.com/codex/tasks/task_e_685ff03337788327990b4277051475cd