### PR TITLE
Fix WebGPU context initialization

### DIFF
--- a/src/renderers/webgpuArenaRenderer.js
+++ b/src/renderers/webgpuArenaRenderer.js
@@ -17,6 +17,10 @@ export class WebGPUArenaRenderer {
         }
         this.device = await adapter.requestDevice();
         this.context = this.canvas.getContext('webgpu');
+        if (!this.context) {
+            console.warn('[WebGPUArenaRenderer] Failed to acquire WebGPU context');
+            return;
+        }
         const format = navigator.gpu.getPreferredCanvasFormat();
         this.context.configure({ device: this.device, format });
     }


### PR DESCRIPTION
## Summary
- handle missing WebGPU context in `WebGPUArenaRenderer` initialization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860143fce948327b5dd51fbcdc7c3e6