### PR TITLE
Implement TensorFlow-based arena winner prediction

### DIFF
--- a/src/arena/arenaManager.js
+++ b/src/arena/arenaManager.js
@@ -52,6 +52,19 @@ class ArenaManager {
         fluctuationEngine.reset();
         this.spawnRandomTeam('A', 12, 100, 400);
         this.spawnRandomTeam('B', 12, 600, 900);
+        if (this.game?.eventManager) {
+            const snapshot = this.game.units.map(u => ({
+                id: u.id,
+                team: u.team,
+                hp: u.hp,
+                attackPower: u.attackPower,
+                defense: u.defense,
+            }));
+            this.game.eventManager.publish('arena_round_start', {
+                round: this.roundCount,
+                units: snapshot,
+            });
+        }
         if (this.combatWorker) {
             this.combatWorker.postMessage({ type: 'init', data: this.game.units.map(u => ({ id: u.id, hp: u.hp })) });
         }
@@ -121,6 +134,7 @@ class ArenaManager {
         };
         dataRecorder.recordMatch(matchData);
         if (this.game?.eventManager) {
+            this.game.eventManager.publish('arena_round_end', { round: this.roundCount, winner });
             this.game.eventManager.publish('arena_log', { eventType: 'round_end', data: matchData });
         }
     }

--- a/src/game.js
+++ b/src/game.js
@@ -71,6 +71,7 @@ import { CommanderManager } from './managers/commanderManager.js';
 import { WorldmapRenderManager } from './rendering/worldMapRenderManager.js';
 import { ArenaLogStorage } from './logging/arenaLogStorage.js';
 import { TFArenaVisualizer } from './tfArenaVisualizer.js';
+import { BattlePredictionManager } from './managers/battlePredictionManager.js';
 
 export class Game {
     constructor() {
@@ -151,6 +152,7 @@ export class Game {
         this.eventManager = new EventManager();
         this.arenaLogStorage = new ArenaLogStorage(this.eventManager);
         this.tfArenaVisualizer = new TFArenaVisualizer(this.arenaLogStorage);
+        this.battlePredictionManager = new BattlePredictionManager(this.eventManager);
         this.tooltipManager = new TooltipManager();
         this.entityManager = new EntityManager(this.eventManager);
         this.groupManager = new GroupManager(this.eventManager, this.entityManager.getEntityById.bind(this.entityManager));

--- a/src/managers/battlePredictionManager.js
+++ b/src/managers/battlePredictionManager.js
@@ -1,0 +1,88 @@
+import tfLoader from '../utils/tf-loader.js';
+
+export class BattlePredictionManager {
+    constructor(eventManager) {
+        this.eventManager = eventManager;
+        this.currentPrediction = null;
+        this.stats = { total: 0, correct: 0 };
+        this.model = null;
+        this.tf = null;
+        this.trainingFeatures = [];
+        this.trainingLabels = [];
+        this.lastFeatures = null;
+        this.init();
+    }
+
+    async init() {
+        await tfLoader.init();
+        this.tf = tfLoader.getTf();
+        if (!this.tf) return;
+
+        this.model = this.tf.sequential();
+        this.model.add(this.tf.layers.dense({ units: 16, activation: 'relu', inputShape: [3] }));
+        this.model.add(this.tf.layers.dense({ units: 1, activation: 'sigmoid' }));
+        this.model.compile({ optimizer: 'adam', loss: 'binaryCrossentropy' });
+
+        this.setupListeners();
+    }
+
+    setupListeners() {
+        if (!this.eventManager) return;
+        this.eventManager.subscribe('arena_round_start', (d) => this.onRoundStart(d));
+        this.eventManager.subscribe('arena_round_end', (d) => this.onRoundEnd(d));
+    }
+
+    extractFeatures(units) {
+        const sum = (arr, prop) => arr.reduce((acc, u) => acc + (u[prop] || 0), 0);
+        const teamA = units.filter(u => u.team === 'A');
+        const teamB = units.filter(u => u.team === 'B');
+        const hpDiff = sum(teamA, 'hp') - sum(teamB, 'hp');
+        const atkDiff = sum(teamA, 'attackPower') - sum(teamB, 'attackPower');
+        const defDiff = sum(teamA, 'defense') - sum(teamB, 'defense');
+        return [hpDiff, atkDiff, defDiff];
+    }
+
+    async onRoundStart({ units }) {
+        if (!this.tf || !units) return;
+        const feat = this.extractFeatures(units);
+        this.lastFeatures = feat;
+        const input = this.tf.tensor2d([feat]);
+        const predTensor = this.model.predict(input);
+        const predVal = (await predTensor.data())[0];
+        this.currentPrediction = predVal >= 0.5 ? 'A' : 'B';
+        input.dispose();
+        predTensor.dispose();
+        this.updateDisplay();
+    }
+
+    async onRoundEnd({ winner }) {
+        if (!this.tf || !winner || !this.lastFeatures) return;
+        this.stats.total++;
+        if (winner === this.currentPrediction) this.stats.correct++;
+        this.trainingFeatures.push(this.lastFeatures);
+        this.trainingLabels.push(winner === 'A' ? 1 : 0);
+        await this.trainModel();
+        this.updateDisplay();
+        this.currentPrediction = null;
+        this.lastFeatures = null;
+    }
+
+    async trainModel() {
+        if (this.trainingFeatures.length < 5) return;
+        const xs = this.tf.tensor2d(this.trainingFeatures);
+        const ys = this.tf.tensor2d(this.trainingLabels, [this.trainingLabels.length, 1]);
+        await this.model.fit(xs, ys, { epochs: 5, batchSize: 8 });
+        xs.dispose();
+        ys.dispose();
+    }
+
+    updateDisplay() {
+        const container = document.getElementById('arena-tf-stats');
+        if (!container) return;
+        container.style.display = 'block';
+        const acc = this.stats.total ? ((this.stats.correct / this.stats.total) * 100).toFixed(1) : 'N/A';
+        const predText = this.currentPrediction ? `예상 승자: 팀 ${this.currentPrediction}` : '';
+        container.textContent = `${predText} | 정확도: ${acc}% (${this.stats.correct}/${this.stats.total})`;
+    }
+}
+

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -46,6 +46,7 @@ import { TooltipManager } from './tooltipManager.js';
 import { BattleManager } from './battleManager.js';
 import { TimerManager } from './timerManager.js';
 import { AgentActionBridge } from './agentActionBridge.js';
+import { BattlePredictionManager } from './battlePredictionManager.js';
 // DataRecorder is only needed in a Node.js environment so we lazy-load it
 let DataRecorder = null;
 if (typeof process !== 'undefined' && process.versions?.node) {
@@ -103,4 +104,5 @@ export {
     BattleManager,
     TimerManager,
     AgentActionBridge,
+    BattlePredictionManager,
 };


### PR DESCRIPTION
## Summary
- add `BattlePredictionManager` to predict arena winners using tfjs and display accuracy
- trigger prediction and result events from `ArenaManager`
- hook prediction manager into `Game` initialization
- export prediction manager via `managers/index.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860163ce39483279d562744409508dd