### PR TITLE
Show best and worst arena units

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
 
     <div id="aquarium" style="display: none;"></div>
     <div id="arena-tf-stats" class="ui-frame" style="display:none;"></div>
+    <div id="arena-round-summary" class="ui-frame" style="display:none;"></div>
 
     <div id="ui-panel" class="ui-frame">
         <h2>플레이어 상태</h2>

--- a/src/arena/arenaManager.js
+++ b/src/arena/arenaManager.js
@@ -132,11 +132,31 @@ class ArenaManager {
             winner: `Team ${winner}`,
             fluctuations: fluctuationEngine.getLog(),
         };
+
+        const { best, worst } = this.getBestAndWorstUnits();
+
         dataRecorder.recordMatch(matchData);
         if (this.game?.eventManager) {
-            this.game.eventManager.publish('arena_round_end', { round: this.roundCount, winner });
+            this.game.eventManager.publish('arena_round_end', {
+                round: this.roundCount,
+                winner,
+                bestUnit: best,
+                worstUnit: worst,
+            });
             this.game.eventManager.publish('arena_log', { eventType: 'round_end', data: matchData });
         }
+    }
+
+    getBestAndWorstUnits() {
+        const alive = this.game.units;
+        if (alive.length === 0) return { best: null, worst: null };
+        let best = alive[0];
+        let worst = alive[0];
+        for (const u of alive) {
+            if (u.hp > best.hp) best = u;
+            if (u.hp < worst.hp) worst = u;
+        }
+        return { best, worst };
     }
 }
 

--- a/src/game.js
+++ b/src/game.js
@@ -72,6 +72,7 @@ import { WorldmapRenderManager } from './rendering/worldMapRenderManager.js';
 import { ArenaLogStorage } from './logging/arenaLogStorage.js';
 import { TFArenaVisualizer } from './tfArenaVisualizer.js';
 import { BattlePredictionManager } from './managers/battlePredictionManager.js';
+import { JOBS } from './data/jobs.js';
 
 export class Game {
     constructor() {
@@ -365,6 +366,12 @@ export class Game {
         this.dataRecorder.init();
         this.arenaLogStorage.init();
         this.eventManager.subscribe('arena_log', () => this.tfArenaVisualizer.renderCharts());
+        this.eventManager.subscribe('arena_round_end', ({ bestUnit, worstUnit }) => {
+            const el = document.getElementById('arena-round-summary');
+            if (!el) return;
+            const fmt = (u) => u ? `팀 ${u.team} ${JOBS[u.jobId]?.name || u.jobId}` : '없음';
+            el.textContent = `MVP: ${fmt(bestUnit)} | 최약체: ${fmt(worstUnit)}`;
+        });
         this.guidelineLoader = new GuidelineLoader(SETTINGS.GUIDELINE_REPO_URL);
         this.guidelineLoader.load();
         if (SETTINGS.ENABLE_POSSESSION_SYSTEM) {
@@ -1455,6 +1462,8 @@ export class Game {
         container.style.display = 'block';
         this.battleCanvas.style.display = 'none';
         this.aquarium.style.display = 'none';
+        const summary = document.getElementById('arena-round-summary');
+        if (summary) summary.style.display = 'none';
     }
 
     showBattleMap() {
@@ -1462,6 +1471,8 @@ export class Game {
         container.style.display = 'none';
         this.battleCanvas.style.display = 'block';
         this.aquarium.style.display = 'none';
+        const summary = document.getElementById('arena-round-summary');
+        if (summary) summary.style.display = 'block';
     }
 
     clearAllUnits() {

--- a/style.css
+++ b/style.css
@@ -602,3 +602,14 @@ body, html {
 }
 .details-list li:last-child { border-bottom: none; }
 .details-list li strong { text-transform: capitalize; }
+
+#arena-round-summary {
+    position: absolute;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    color: white;
+    font-size: 20px;
+    text-shadow: 0 0 5px black;
+    pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- expose an arena round summary element in the HTML and style it
- compute best and worst remaining units after each arena match
- publish the result to `arena_round_end` event
- show the MVP and weakest unit inside the arena when rounds end

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68601867ad8083279ee4125e6cfd9aa4