### PR TITLE
Implement battle prediction memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 * **3-Lane 오버레이:** 전장에 세 갈래 길이 표시되어 라인 전투 실험에 활용할 수 있습니다.
 * **전투 맵 드래그 지원:** 마우스로 전장을 드래그하여 자유롭게 카메라를 이동할 수 있으며, 키보드를 누르면 다시 플레이어를 따라갑니다.
 * **포그 오브 워 토글:** `config/gameSettings.js`의 `ENABLE_FOG_OF_WAR` 값을 통해 안개 효과를 켜거나 끌 수 있습니다. 게임 도중 값을 변경하면 즉시 반영됩니다.
+* **예측 메모리 시스템:** TensorFlow 연산을 전용 Web Worker가 처리하며, 각 전투의 승부 예측과 MVP 정보를 IndexedDB에 저장합니다.
 * **TensorFlow 길찾기 토글:** `config/gameSettings.js`의 `ENABLE_TENSORFLOW_PATHING`을 활성화하면 학습된 모델을 이용해 보다 자연스러운 경로를 계산합니다. 기본값은 꺼져 있으며, 모델 파일이 없을 경우 자동으로 기존 BFS 로직을 사용합니다.
 * **평판 시스템 토글:** `config/gameSettings.js`의 `ENABLE_REPUTATION_SYSTEM` 값을 false로 설정하면 평판 기록과 모델 로드를 생략하여 성능을 높일 수 있습니다.
 

--- a/src/arena/arenaManager.js
+++ b/src/arena/arenaManager.js
@@ -133,7 +133,14 @@ class ArenaManager {
             fluctuations: fluctuationEngine.getLog(),
         };
 
-        const { best, worst } = this.getBestAndWorstUnits();
+        const { best, worst, bestReason, worstReason } = this.getBestAndWorstUnits();
+        const snapshot = this.game.units.map(u => ({
+            id: u.id,
+            team: u.team,
+            hp: u.hp,
+            attackPower: u.attackPower,
+            defense: u.defense,
+        }));
 
         dataRecorder.recordMatch(matchData);
         if (this.game?.eventManager) {
@@ -142,6 +149,9 @@ class ArenaManager {
                 winner,
                 bestUnit: best,
                 worstUnit: worst,
+                bestReason,
+                worstReason,
+                units: snapshot,
             });
             this.game.eventManager.publish('arena_log', { eventType: 'round_end', data: matchData });
         }
@@ -149,14 +159,19 @@ class ArenaManager {
 
     getBestAndWorstUnits() {
         const alive = this.game.units;
-        if (alive.length === 0) return { best: null, worst: null };
+        if (alive.length === 0) return { best: null, worst: null, bestReason: '', worstReason: '' };
         let best = alive[0];
         let worst = alive[0];
         for (const u of alive) {
             if (u.hp > best.hp) best = u;
             if (u.hp < worst.hp) worst = u;
         }
-        return { best, worst };
+        return {
+            best,
+            worst,
+            bestReason: 'highest HP remaining',
+            worstReason: 'lowest HP remaining'
+        };
     }
 }
 

--- a/src/game.js
+++ b/src/game.js
@@ -72,6 +72,7 @@ import { WorldmapRenderManager } from './rendering/worldMapRenderManager.js';
 import { ArenaLogStorage } from './logging/arenaLogStorage.js';
 import { TFArenaVisualizer } from './tfArenaVisualizer.js';
 import { BattlePredictionManager } from './managers/battlePredictionManager.js';
+import { BattleMemoryManager } from './managers/battleMemoryManager.js';
 import { JOBS } from './data/jobs.js';
 
 export class Game {
@@ -154,6 +155,7 @@ export class Game {
         this.arenaLogStorage = new ArenaLogStorage(this.eventManager);
         this.tfArenaVisualizer = new TFArenaVisualizer(this.arenaLogStorage);
         this.battlePredictionManager = new BattlePredictionManager(this.eventManager);
+        this.battleMemoryManager = new BattleMemoryManager(this.eventManager);
         this.tooltipManager = new TooltipManager();
         this.entityManager = new EntityManager(this.eventManager);
         this.groupManager = new GroupManager(this.eventManager, this.entityManager.getEntityById.bind(this.entityManager));
@@ -366,11 +368,13 @@ export class Game {
         this.dataRecorder.init();
         this.arenaLogStorage.init();
         this.eventManager.subscribe('arena_log', () => this.tfArenaVisualizer.renderCharts());
-        this.eventManager.subscribe('arena_round_end', ({ bestUnit, worstUnit }) => {
+        this.eventManager.subscribe('arena_round_end', (data) => {
+            const { bestUnit, worstUnit } = data;
             const el = document.getElementById('arena-round-summary');
-            if (!el) return;
-            const fmt = (u) => u ? `팀 ${u.team} ${JOBS[u.jobId]?.name || u.jobId}` : '없음';
-            el.textContent = `MVP: ${fmt(bestUnit)} | 최약체: ${fmt(worstUnit)}`;
+            if (el) {
+                const fmt = (u) => u ? `팀 ${u.team} ${JOBS[u.jobId]?.name || u.jobId}` : '없음';
+                el.textContent = `MVP: ${fmt(bestUnit)} | 최약체: ${fmt(worstUnit)}`;
+            }
         });
         this.guidelineLoader = new GuidelineLoader(SETTINGS.GUIDELINE_REPO_URL);
         this.guidelineLoader.load();

--- a/src/managers/battleMemoryManager.js
+++ b/src/managers/battleMemoryManager.js
@@ -1,0 +1,53 @@
+// src/managers/battleMemoryManager.js
+
+export class BattleMemoryManager {
+    constructor(eventManager) {
+        this.eventManager = eventManager;
+        this.worker = null;
+        this.currentFeatures = null;
+        this.currentPrediction = null;
+        this.initWorker();
+        this.setupListeners();
+    }
+
+    initWorker() {
+        try {
+            this.worker = new Worker('src/workers/battleMemoryWorker.js', { type: 'module' });
+            this.worker.onmessage = (e) => {
+                if (e.data.type === 'modelUpdated') {
+                    console.log('[BattleMemoryManager] Worker updated prediction model.');
+                }
+            };
+            this.worker.postMessage({ type: 'init' });
+        } catch (e) {
+            console.warn('[BattleMemoryManager] Failed to start worker', e);
+            this.worker = null;
+        }
+    }
+
+    setupListeners() {
+        if (!this.eventManager) return;
+        this.eventManager.subscribe('battle_prediction_made', ({ features, prediction }) => {
+            this.currentFeatures = features;
+            this.currentPrediction = prediction;
+        });
+        this.eventManager.subscribe('arena_round_end', (data) => this.onRoundEnd(data));
+    }
+
+    onRoundEnd({ winner, bestUnit, worstUnit, bestReason, worstReason, units }) {
+        if (!this.worker || !this.currentFeatures) return;
+        const memory = {
+            features: this.currentFeatures,
+            prediction: this.currentPrediction,
+            winner,
+            bestUnit: bestUnit ? { id: bestUnit.id, team: bestUnit.team, reason: bestReason } : null,
+            worstUnit: worstUnit ? { id: worstUnit.id, team: worstUnit.team, reason: worstReason } : null,
+            units: (units || []).map(u => ({ id: u.id, team: u.team, hp: u.hp, attackPower: u.attackPower, defense: u.defense }))
+        };
+        this.worker.postMessage({ type: 'saveMemory', data: memory });
+        this.worker.postMessage({ type: 'train' });
+        this.currentFeatures = null;
+        this.currentPrediction = null;
+    }
+}
+

--- a/src/managers/battlePredictionManager.js
+++ b/src/managers/battlePredictionManager.js
@@ -52,6 +52,12 @@ export class BattlePredictionManager {
         this.currentPrediction = predVal >= 0.5 ? 'A' : 'B';
         input.dispose();
         predTensor.dispose();
+        if (this.eventManager) {
+            this.eventManager.publish('battle_prediction_made', {
+                features: feat,
+                prediction: this.currentPrediction,
+            });
+        }
         this.updateDisplay();
     }
 

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -47,6 +47,7 @@ import { BattleManager } from './battleManager.js';
 import { TimerManager } from './timerManager.js';
 import { AgentActionBridge } from './agentActionBridge.js';
 import { BattlePredictionManager } from './battlePredictionManager.js';
+import { BattleMemoryManager } from './battleMemoryManager.js';
 // DataRecorder is only needed in a Node.js environment so we lazy-load it
 let DataRecorder = null;
 if (typeof process !== 'undefined' && process.versions?.node) {
@@ -105,4 +106,5 @@ export {
     TimerManager,
     AgentActionBridge,
     BattlePredictionManager,
+    BattleMemoryManager,
 };

--- a/src/workers/battleMemoryWorker.js
+++ b/src/workers/battleMemoryWorker.js
@@ -1,0 +1,106 @@
+// src/workers/battleMemoryWorker.js
+
+let tf = self.tf;
+
+const DB_NAME = 'BattleMemoryDB';
+const STORE_MEM = 'memories';
+const STORE_MODEL = 'model';
+
+let db = null;
+let model = null;
+
+async function openDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_MEM)) {
+        db.createObjectStore(STORE_MEM, { keyPath: 'id', autoIncrement: true });
+      }
+      if (!db.objectStoreNames.contains(STORE_MODEL)) {
+        db.createObjectStore(STORE_MODEL);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function loadModel() {
+  if (!db || !tf) return;
+  const tx = db.transaction(STORE_MODEL, 'readonly');
+  const req = tx.objectStore(STORE_MODEL).get('weights');
+  return new Promise((res) => {
+    req.onsuccess = async () => {
+      const data = req.result;
+      if (data) {
+        model = await tf.loadLayersModel(tf.io.fromMemory(data.modelTopology, data.weightSpecs, data.weightData));
+      }
+      res();
+    };
+    req.onerror = () => res();
+  });
+}
+
+async function saveModel() {
+  if (!db || !model) return;
+  const artifacts = await model.save(tf.io.withSaveHandler(async (artifacts) => artifacts));
+  const tx = db.transaction(STORE_MODEL, 'readwrite');
+  tx.objectStore(STORE_MODEL).put(artifacts, 'weights');
+}
+
+function ensureModel() {
+  if (!tf) return;
+  if (!model) {
+    model = tf.sequential();
+    model.add(tf.layers.dense({ units: 16, activation: 'relu', inputShape: [3] }));
+    model.add(tf.layers.dense({ units: 1, activation: 'sigmoid' }));
+    model.compile({ optimizer: 'adam', loss: 'binaryCrossentropy' });
+  }
+}
+
+async function getAllMemories() {
+  if (!db) return [];
+  const tx = db.transaction(STORE_MEM, 'readonly');
+  const req = tx.objectStore(STORE_MEM).getAll();
+  return new Promise((res) => { req.onsuccess = () => res(req.result || []); });
+}
+
+async function trainFromMemories() {
+  if (!tf) return;
+  const mems = await getAllMemories();
+  if (mems.length === 0) return;
+  const xs = tf.tensor2d(mems.map(m => m.features));
+  const ys = tf.tensor2d(mems.map(m => [m.winner === 'A' ? 1 : 0]));
+  await model.fit(xs, ys, { epochs: 5, batchSize: 8 });
+  xs.dispose();
+  ys.dispose();
+  await saveModel();
+  postMessage({ type: 'modelUpdated' });
+}
+
+onmessage = async (e) => {
+  const { type, data } = e.data;
+  if (type === 'init') {
+    db = await openDB();
+    ensureModel();
+    await loadModel();
+    postMessage({ type: 'ready' });
+  } else if (type === 'saveMemory') {
+    if (!db) return;
+    const tx = db.transaction(STORE_MEM, 'readwrite');
+    tx.objectStore(STORE_MEM).add(data);
+  } else if (type === 'train') {
+    ensureModel();
+    await trainFromMemories();
+  } else if (type === 'predict') {
+    if (!model || !tf) { postMessage({ type: 'predicted', prediction: 'A' }); return; }
+    const tensor = tf.tensor2d([data.features]);
+    const pred = model.predict(tensor);
+    const val = (await pred.data())[0];
+    tensor.dispose();
+    pred.dispose();
+    postMessage({ type: 'predicted', prediction: val >= 0.5 ? 'A' : 'B' });
+  }
+};
+


### PR DESCRIPTION
## Summary
- save battle prediction rounds with Web Worker
- track best and worst unit reasons for each round
- store predictions in IndexedDB via `BattleMemoryWorker`
- add `BattleMemoryManager` and hook into game flow
- document the new system in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68601acb91388327afde596a41ce2bba