### PR TITLE
Implement arena log and speed-up

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,6 +86,10 @@
         <div id="combat-log-content"></div>
     </div>
 
+    <div id="arena-log-panel" class="ui-frame">
+        <div id="arena-log-content"></div>
+    </div>
+
     <div id="system-log-panel" class="ui-frame">
         <div class="log-title">-- SYSTEM LOG --</div>
         <div id="system-log-content"></div>

--- a/src/arena/arenaManager.js
+++ b/src/arena/arenaManager.js
@@ -24,9 +24,26 @@ class ArenaManager {
                     if (target) {
                         const wasAlive = target.hp > 0;
                         target.hp = e.data.remainingHp;
+                        const attacker = this.game.units.find(u => u.id === e.data.attackerId);
+                        if (this.game?.eventManager) {
+                            this.game.eventManager.publish('arena_log', {
+                                eventType: 'attack',
+                                attackerId: e.data.attackerId,
+                                defenderId: e.data.defenderId,
+                                damage: e.data.damage,
+                                message: `${attacker?.id || 'unknown'} -> ${target.id} (${e.data.damage})`
+                            });
+                        }
                         if (wasAlive && target.hp <= 0) {
-                            const killer = this.game.units.find(u => u.id === e.data.attackerId);
+                            const killer = attacker;
                             if (killer) killer.kills++;
+                            if (this.game?.eventManager) {
+                                this.game.eventManager.publish('arena_log', {
+                                    eventType: 'unit_death',
+                                    unitId: target.id,
+                                    message: `${target.id} 사망`
+                                });
+                            }
                         }
                     }
                 }
@@ -36,6 +53,7 @@ class ArenaManager {
 
     start() {
         this.isActive = true;
+        if (this.game.gameLoop) this.game.gameLoop.timeScale = 5;
         this.game.clearAllUnits();
         console.log("\u2694\ufe0f \uc544\ub808\ub098\uc5d0 \uc624\uc2e0 \uac83\uc744 \ud658\uc601\ud569\ub2c8\ub2e4! AI \uc790\ub3d9 \ub300\ub825\uc744 \uc2dc\uc791\ud569\ub2c8\ub2e4.");
         this.game.showBattleMap();
@@ -45,6 +63,7 @@ class ArenaManager {
 
     stop() {
         this.isActive = false;
+        if (this.game.gameLoop) this.game.gameLoop.timeScale = 1;
         this.game.showWorldMap();
         this.game.gameState.currentState = 'WORLD';
         console.log(`\ud83d\udc4b \uc544\ub808\ub098\ub97c \ub5a0\ub0a0\uae4c. \ucd1d ${this.roundCount} \ub77c\uc6b4\ub4dc\uc758 \ub370\uc774\ud130\uac00 \uae30\ub85d\ub418\uc5c8\uc2b5\ub2c8\ub2e4.`);
@@ -56,6 +75,13 @@ class ArenaManager {
         console.log(`======== \ub77c\uc6b4\ub4dc ${this.roundCount} \uc2dc\uc791 ========`);
         this.game.clearAllUnits();
         fluctuationEngine.reset();
+        if (this.game?.eventManager) {
+            this.game.eventManager.publish('arena_log', {
+                eventType: 'round_start',
+                round: this.roundCount,
+                message: `Round ${this.roundCount} 시작`
+            });
+        }
         this.spawnRandomTeam('A', 12, 100, 400);
         this.spawnRandomTeam('B', 12, 600, 900);
         if (this.game?.eventManager) {
@@ -110,7 +136,25 @@ class ArenaManager {
                 } else {
                     const prevHp = defender.hp;
                     defender.hp -= damage;
-                    if (prevHp > 0 && defender.hp <= 0) attacker.kills++;
+                    if (this.game?.eventManager) {
+                        this.game.eventManager.publish('arena_log', {
+                            eventType: 'attack',
+                            attackerId: attacker.id,
+                            defenderId: defender.id,
+                            damage,
+                            message: `${attacker.id} -> ${defender.id} (${damage})`
+                        });
+                    }
+                    if (prevHp > 0 && defender.hp <= 0) {
+                        attacker.kills++;
+                        if (this.game?.eventManager) {
+                            this.game.eventManager.publish('arena_log', {
+                                eventType: 'unit_death',
+                                unitId: defender.id,
+                                message: `${defender.id} 사망`
+                            });
+                        }
+                    }
                 }
             };
             this.game.addUnit(unit);
@@ -134,6 +178,8 @@ class ArenaManager {
             winner = 'B';
         } else if (teamB_units.length === 0 && teamA_units.length > 0) {
             winner = 'A';
+        } else if (teamA_units.length === 0 && teamB_units.length === 0) {
+            winner = 'DRAW';
         }
         if (winner) {
             console.log(`\ud83c\udfc6 \ub77c\uc6b4\ub4dc ${this.roundCount} \uc885\ub8cc! \uc2b9\uc790: \ud300 ${winner}`);
@@ -181,7 +227,11 @@ class ArenaManager {
                 worstReason,
                 units: snapshot,
             });
-            this.game.eventManager.publish('arena_log', { eventType: 'round_end', data: matchData });
+            this.game.eventManager.publish('arena_log', {
+                eventType: 'round_end',
+                data: matchData,
+                message: `Round ${this.roundCount} 종료 - 승자: ${winner}`
+            });
         }
     }
 

--- a/src/game.js
+++ b/src/game.js
@@ -74,6 +74,7 @@ import { TFArenaVisualizer } from './tfArenaVisualizer.js';
 import { BattlePredictionManager } from './managers/battlePredictionManager.js';
 import { BattleMemoryManager } from './managers/battleMemoryManager.js';
 import { JOBS } from './data/jobs.js';
+import { ArenaUIManager } from './managers/arenaUIManager.js';
 
 export class Game {
     constructor() {
@@ -156,6 +157,7 @@ export class Game {
         this.tfArenaVisualizer = new TFArenaVisualizer(this.arenaLogStorage);
         this.battlePredictionManager = new BattlePredictionManager(this.eventManager);
         this.battleMemoryManager = new BattleMemoryManager(this.eventManager);
+        this.arenaUIManager = new ArenaUIManager(this.eventManager);
         this.tooltipManager = new TooltipManager();
         this.entityManager = new EntityManager(this.eventManager);
         this.groupManager = new GroupManager(this.eventManager, this.entityManager.getEntityById.bind(this.entityManager));
@@ -368,15 +370,6 @@ export class Game {
         this.dataRecorder.init();
         this.arenaLogStorage.init();
         this.eventManager.subscribe('arena_log', () => this.tfArenaVisualizer.renderCharts());
-        this.eventManager.subscribe('arena_round_end', (data) => {
-            const { bestUnit, worstUnit, bestReason, worstReason } = data;
-            const el = document.getElementById('arena-round-summary');
-            if (el) {
-                const fmt = (u) => u ? `팀 ${u.team} ${JOBS[u.jobId]?.name || u.jobId}` : '없음';
-                el.textContent = `MVP: ${fmt(bestUnit)} (${bestReason}) | 최약체: ${fmt(worstUnit)} (${worstReason})`;
-                el.style.display = 'block';
-            }
-        });
         this.guidelineLoader = new GuidelineLoader(SETTINGS.GUIDELINE_REPO_URL);
         this.guidelineLoader.load();
         if (SETTINGS.ENABLE_POSSESSION_SYSTEM) {
@@ -1467,8 +1460,7 @@ export class Game {
         container.style.display = 'block';
         this.battleCanvas.style.display = 'none';
         this.aquarium.style.display = 'none';
-        const summary = document.getElementById('arena-round-summary');
-        if (summary) summary.style.display = 'none';
+        this.arenaUIManager?.onShowWorldMap();
     }
 
     showBattleMap() {
@@ -1476,8 +1468,7 @@ export class Game {
         container.style.display = 'none';
         this.battleCanvas.style.display = 'block';
         this.aquarium.style.display = 'none';
-        const summary = document.getElementById('arena-round-summary');
-        if (summary) summary.style.display = 'block';
+        this.arenaUIManager?.onShowBattleMap();
     }
 
     clearAllUnits() {

--- a/src/managers/arenaUIManager.js
+++ b/src/managers/arenaUIManager.js
@@ -1,0 +1,58 @@
+export class ArenaCombatLogManager {
+    constructor(eventManager) {
+        this.logs = [];
+        this.logElement = document.getElementById('arena-log-content');
+        eventManager.subscribe('arena_log', data => {
+            if (data && data.message) this.add(data.message);
+        });
+    }
+
+    add(message) {
+        this.logs.push(message);
+        if (this.logs.length > 30) this.logs.shift();
+        this.render();
+    }
+
+    clear() {
+        this.logs = [];
+        this.render();
+    }
+
+    render() {
+        if (!this.logElement) return;
+        const el = this.logElement;
+        const atBottom = Math.abs(el.scrollHeight - el.clientHeight - el.scrollTop) < 5;
+        el.innerHTML = this.logs.join('<br>');
+        if (atBottom) el.scrollTop = el.scrollHeight;
+    }
+}
+
+export class ArenaUIManager {
+    constructor(eventManager) {
+        this.eventManager = eventManager;
+        this.summaryElement = document.getElementById('arena-round-summary');
+        this.logManager = new ArenaCombatLogManager(eventManager);
+        eventManager.subscribe('arena_round_end', data => this.displaySummary(data));
+    }
+
+    displaySummary(data) {
+        if (!this.summaryElement) return;
+        const { bestUnit, worstUnit, bestReason, worstReason, round } = data || {};
+        const fmt = (u) => u ? `팀 ${u.team} ${u.jobId}` : '없음';
+        this.summaryElement.textContent = `Round ${round} - MVP: ${fmt(bestUnit)} (${bestReason}) | 최약체: ${fmt(worstUnit)} (${worstReason})`;
+        this.summaryElement.style.display = 'block';
+    }
+
+    hideSummary() {
+        if (this.summaryElement) this.summaryElement.style.display = 'none';
+    }
+
+    onShowWorldMap() {
+        this.hideSummary();
+        this.logManager.clear();
+    }
+
+    onShowBattleMap() {
+        if (this.summaryElement) this.summaryElement.style.display = 'block';
+    }
+}

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -48,6 +48,7 @@ import { TimerManager } from './timerManager.js';
 import { AgentActionBridge } from './agentActionBridge.js';
 import { BattlePredictionManager } from './battlePredictionManager.js';
 import { BattleMemoryManager } from './battleMemoryManager.js';
+import { ArenaUIManager } from './arenaUIManager.js';
 // DataRecorder is only needed in a Node.js environment so we lazy-load it
 let DataRecorder = null;
 if (typeof process !== 'undefined' && process.versions?.node) {
@@ -107,4 +108,5 @@ export {
     AgentActionBridge,
     BattlePredictionManager,
     BattleMemoryManager,
+    ArenaUIManager,
 };

--- a/style.css
+++ b/style.css
@@ -36,7 +36,7 @@ body, html {
 #weather-canvas     { z-index: 60; }
 
 /* 고정 HUD UI (100-199) */
-#ui-panel, #combat-log-panel, #system-log-panel, #minimap-canvas, #skill-bar {
+#ui-panel, #combat-log-panel, #arena-log-panel, #system-log-panel, #minimap-canvas, #skill-bar {
     position: fixed;
     z-index: 100;
 }
@@ -225,6 +225,16 @@ body, html {
 #combat-log-panel {
     bottom: 20px;
     left: 20px;
+    width: 400px;
+    height: 150px;
+    font-size: 12px;
+    padding: 10px;
+    overflow-y: auto;
+}
+
+#arena-log-panel {
+    bottom: 20px;
+    left: 450px;
     width: 400px;
     height: 150px;
     font-size: 12px;


### PR DESCRIPTION
## Summary
- speed up arena rounds by adjusting GameLoop timescale
- log arena attacks, unit deaths, and round transitions
- show arena logs and round summary via new ArenaUIManager
- expose arena log panel in UI and style it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68601f568814832785e0182ec9308515