### PR TITLE
Integrate weapon AI into arena units

### DIFF
--- a/src/arena/TensorFlowController.js
+++ b/src/arena/TensorFlowController.js
@@ -12,7 +12,7 @@ export class TensorFlowController {
         }
     }
 
-    decideAction(unit, units) {
+    decideAction(unit, units, hint = null) {
         const enemies = units.filter(u => u.team !== unit.team && u.isAlive());
         if (enemies.length === 0) return { type: 'idle' };
         let nearest = enemies[0];
@@ -26,6 +26,11 @@ export class TensorFlowController {
         }
         const dirX = (nearest.x - unit.x) / minD;
         const dirY = (nearest.y - unit.y) / minD;
-        return { type: 'move', dx: dirX * unit.speed, dy: dirY * unit.speed };
+        const baseAction = { type: 'move', dx: dirX * unit.speed, dy: dirY * unit.speed };
+        if (hint && hint.type && hint.type !== 'idle') {
+            // follow hint when our base action is idle-like
+            return hint;
+        }
+        return baseAction;
     }
 }

--- a/src/arena/arenaManager.js
+++ b/src/arena/arenaManager.js
@@ -115,7 +115,8 @@ class ArenaManager {
                 `${teamName}-${jobId}-${i}`,
                 teamName,
                 jobId,
-                { x: xMin + Math.random() * (xMax - xMin), y: Math.random() * 600 }
+                { x: xMin + Math.random() * (xMax - xMin), y: Math.random() * 600 },
+                this.game.microItemAIManager
             );
 
             const wId = weaponIds[Math.floor(Math.random() * weaponIds.length)];


### PR DESCRIPTION
## Summary
- ensure arena units receive MicroItemAIManager when spawned
- extend arena Unit to use weapon AI and hint TensorFlow controller
- allow TensorFlow controller to accept hint actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686024ca244883279d12ee9886abea02