### PR TITLE
Integrate weapon hint with arena TensorFlow

### DIFF
--- a/src/arena/TensorFlowController.js
+++ b/src/arena/TensorFlowController.js
@@ -26,9 +26,10 @@ export class TensorFlowController {
         }
         const dirX = (nearest.x - unit.x) / minD;
         const dirY = (nearest.y - unit.y) / minD;
-        const baseAction = { type: 'move', dx: dirX * unit.speed, dy: dirY * unit.speed };
+        const target = { x: unit.x + dirX * unit.speed, y: unit.y + dirY * unit.speed };
+        const baseAction = { type: 'move', target, dx: dirX * unit.speed, dy: dirY * unit.speed };
         if (hint && hint.type && hint.type !== 'idle') {
-            // follow hint when our base action is idle-like
+            // Use weapon AI hint as guideline
             return hint;
         }
         return baseAction;

--- a/src/arena/Unit.js
+++ b/src/arena/Unit.js
@@ -92,12 +92,17 @@ class Unit {
 
     executeAction(action, deltaTime) {
         if (!action) return;
-        if (action.type === 'move' && action.target) {
-            const dx = action.target.x - this.x;
-            const dy = action.target.y - this.y;
-            const dist = Math.hypot(dx, dy) || 1;
-            this.x += (dx / dist) * this.speed * deltaTime;
-            this.y += (dy / dist) * this.speed * deltaTime;
+        if (action.type === 'move') {
+            if (action.target) {
+                const dx = action.target.x - this.x;
+                const dy = action.target.y - this.y;
+                const dist = Math.hypot(dx, dy) || 1;
+                this.x += (dx / dist) * this.speed * deltaTime;
+                this.y += (dy / dist) * this.speed * deltaTime;
+            } else if (typeof action.dx === 'number' && typeof action.dy === 'number') {
+                this.x += action.dx * deltaTime;
+                this.y += action.dy * deltaTime;
+            }
         } else if (action.type === 'attack' && action.target && this.attackCooldown <= 0) {
             const target = action.target;
             if (!target.isAlive()) return;


### PR DESCRIPTION
## Summary
- TensorFlowController now returns a move action with a target
- added support for `dx`/`dy` move actions in `Unit.executeAction`
- weapon AI hint is prioritized in TensorFlow controller

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686038c0c9d0832783a1fbfea9118428