### PR TITLE
Fix arena unit check

### DIFF
--- a/src/arena/arenaManager.js
+++ b/src/arena/arenaManager.js
@@ -185,8 +185,12 @@ class ArenaManager {
             this.combatWorker.postMessage({ type: 'updateUnits', data: this.game.units.map(u => ({ id: u.id, hp: u.hp })) });
         }
 
-        const teamA_units = this.game.units.filter(u => u.team === 'A' && u.isAlive());
-        const teamB_units = this.game.units.filter(u => u.team === 'B' && u.isAlive());
+        const teamA_units = this.game.units.filter(
+            u => u.team === 'A' && (typeof u.isAlive === 'function' ? u.isAlive() : u.hp > 0)
+        );
+        const teamB_units = this.game.units.filter(
+            u => u.team === 'B' && (typeof u.isAlive === 'function' ? u.isAlive() : u.hp > 0)
+        );
         let winner = null;
         if (teamA_units.length === 0 && teamB_units.length > 0) {
             winner = 'B';

--- a/src/entities.js
+++ b/src/entities.js
@@ -222,6 +222,11 @@ class Entity {
         }
     }
 
+    /** 현재 HP가 0 이상인지 확인한다 */
+    isAlive() {
+        return this.hp > 0;
+    }
+
     takeDamage(damage) {
         if (this.shield > 0) {
             const blocked = Math.min(this.shield, damage);


### PR DESCRIPTION
## Summary
- add a simple `isAlive` method to `Entity`
- guard `arenaManager` winner logic when units lack `isAlive`

## Testing
- `npm test` *(fails to access some resources but test suites run)*

------
https://chatgpt.com/codex/tasks/task_e_68604ab9d11c8327a9fb09ca6face487