### PR TITLE
Fix newline parsing error

### DIFF
--- a/src/managers/cinematicManager.js
+++ b/src/managers/cinematicManager.js
@@ -29,7 +29,8 @@ export class CinematicManager {
     }
 
     triggerMicroWorldJudgement(target) {
-        this.triggerCinematic(target, 'MICROWORLD JUDGEMENT!', 2000);
+        const text = `MICROWORLD JUDGEMENT!`;
+        this.triggerCinematic(target, text, 2000);
     }
 
     triggerCinematic(target, text, duration) {


### PR DESCRIPTION
## Summary
- prevent potential newline parsing issue in CinematicManager

## Testing
- `npm test` *(fails: TensorFlow libraries not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_68604c3e56dc83278fe9dbe4b5c58594