### PR TITLE
Implement BattleLog cleanup and map system reset

### DIFF
--- a/src/fish/fishManager.js
+++ b/src/fish/fishManager.js
@@ -1,0 +1,15 @@
+export class FishManager {
+    constructor(game, width, height) {
+        this.game = game;
+        this.width = width;
+        this.height = height;
+    }
+
+    start() {
+        console.log('FishManager started');
+    }
+
+    stop() {
+        console.log('FishManager stopped');
+    }
+}

--- a/src/managers/eventManager.js
+++ b/src/managers/eventManager.js
@@ -9,6 +9,15 @@ export class EventManager {
         }
         this.listeners[eventName].push(callback);
     }
+    unsubscribe(eventName, callback) {
+        const listeners = this.listeners[eventName];
+        if (listeners) {
+            const index = listeners.indexOf(callback);
+            if (index !== -1) {
+                listeners.splice(index, 1);
+            }
+        }
+    }
     publish(eventName, data) {
         if (this.listeners[eventName]) {
             this.listeners[eventName].forEach(callback => {

--- a/src/maps/mapManager.js
+++ b/src/maps/mapManager.js
@@ -1,0 +1,76 @@
+import { ArenaManager } from '../arena/arenaManager.js';
+import { FishManager } from '../fish/fishManager.js';
+import { BattleLog } from '../systems/battleLog.js';
+
+export class MapManager {
+    constructor(game) {
+        this.game = game;
+        this.maps = {
+            'arena': { name: '아레나', key: 'arena', width: 1000, height: 600, tilemap: 'assets/maps/arena.json' },
+            'aquarium': { name: '수족관', key: 'aquarium', width: 1200, height: 800, tilemap: 'assets/maps/aquarium.json' },
+        };
+        this.currentMapKey = null;
+    }
+
+    async loadMap(mapKey) {
+        if (!this.maps[mapKey]) {
+            console.error(`맵을 찾을 수 없습니다: ${mapKey}`);
+            return;
+        }
+
+        console.log("이전 맵의 시스템을 정리합니다.");
+        if (this.game.battleLog) {
+            this.game.battleLog.destroy();
+            this.game.battleLog = null;
+        }
+        if (this.game.arenaManager) {
+            this.game.arenaManager = null;
+        }
+        if (this.game.fishManager) {
+            this.game.fishManager.stop();
+            this.game.fishManager = null;
+        }
+
+        this.currentMapKey = mapKey;
+        const mapConfig = this.maps[mapKey];
+
+        await this.game.assetManager.loadTilemap(mapKey, mapConfig.tilemap);
+        this.game.world.setWorldSize(mapConfig.width, mapConfig.height);
+        this.game.tilemapManager.createMap(mapKey);
+
+        if (this.game.systemManager) {
+            this.game.systemManager.clearSystems();
+        }
+
+        this.game.clearAllUnits();
+
+        if (mapKey === 'arena') {
+            this.setupArenaSystems();
+        } else if (mapKey === 'aquarium') {
+            this.setupAquariumSystems();
+        }
+
+        if (this.game.eventManager) {
+            this.game.eventManager.publish('map_loaded', { mapKey: mapKey });
+        }
+
+        console.log(`${mapConfig.name} 맵 로드 완료.`);
+    }
+
+    setupArenaSystems() {
+        console.log("아레나 시스템 설정 중...");
+        this.game.arenaManager = new ArenaManager(this.game);
+        if (this.game.arenaTensorFlowManager) {
+            console.log('Arena TensorFlow Manager가 이미 활성화되어 있습니다.');
+        } else {
+            // 필요하다면 여기서 생성
+        }
+    }
+
+    setupAquariumSystems() {
+        console.log("수족관 시스템 설정 중...");
+        this.game.fishManager = new FishManager(this.game, this.game.world.width, this.game.world.height);
+        this.game.battleLog = new BattleLog(this.game.eventManager);
+        this.game.fishManager.start();
+    }
+}

--- a/src/systems/battleLog.js
+++ b/src/systems/battleLog.js
@@ -1,0 +1,32 @@
+class BattleLog {
+    constructor(eventManager) {
+        this.eventManager = eventManager;
+        this.boundLogAttack = this.logAttack.bind(this);
+        this.boundLogDeath = this.logDeath.bind(this);
+
+        this.eventManager.subscribe('unit_attack', this.boundLogAttack);
+        this.eventManager.subscribe('unit_death', this.boundLogDeath);
+    }
+
+    logAttack(data) {
+        const { attacker, target, damage } = data;
+        this.eventManager.publish('battle_log', {
+            message: `${attacker.id}\uAC00 ${target.id}\uB97C \uACF5\uACA9\uD558\uC5EC ${damage}\uC758 \uD53C\uD574\uB97C \uC785\uD588\uC2B5\uB2C8\uB2E4.`
+        });
+    }
+
+    logDeath(data) {
+        const { unit } = data;
+        this.eventManager.publish('battle_log', {
+            message: `${unit.id}\uAC00 \uC4F0\uB808\uC84C\uC2B5\uB2C8\uB2E4.`
+        });
+    }
+
+    destroy() {
+        this.eventManager.unsubscribe('unit_attack', this.boundLogAttack);
+        this.eventManager.unsubscribe('unit_death', this.boundLogDeath);
+        console.log('BattleLog \uC2DC\uC2A4\uD15C\uC774 \uD30C\uAD34\uB418\uACE0 \uC774\uBCA4\uD2B8 \uAD6C\uB3C5\uC774 \uCDE8\uC18C\uB418\uC5C8\uC2B5\uB2C8\uB2E4.');
+    }
+}
+
+export { BattleLog };


### PR DESCRIPTION
## Summary
- add `FishManager` stub
- extend `EventManager` with `unsubscribe`
- create `BattleLog` system with a destroy method
- add `MapManager` to clean up old systems before loading maps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686094c4a2788327a6ca9e03b8110100