### PR TITLE
Fix BattleManager eventManager fallback

### DIFF
--- a/src/managers/battleManager.js
+++ b/src/managers/battleManager.js
@@ -6,11 +6,15 @@ import { EventManager } from './eventManager.js';
 export class BattleManager {
     constructor(game, eventManager, groupManager, entityManager, factory) {
         this.game = game;
-        if (!eventManager || typeof eventManager.subscribe !== 'function') {
+        const valid = (em) => em && typeof em.subscribe === 'function' && typeof em.publish === 'function';
+        if (valid(eventManager)) {
+            this.eventManager = eventManager;
+        } else if (valid(game?.eventManager)) {
+            console.warn('[BattleManager] Provided eventManager is invalid; falling back to game.eventManager');
+            this.eventManager = game.eventManager;
+        } else {
             console.warn('[BattleManager] Provided eventManager is invalid; using a new instance');
             this.eventManager = new EventManager();
-        } else {
-            this.eventManager = eventManager;
         }
         this.groupManager = groupManager;
         this.entityManager = entityManager;

--- a/tests/unit/battleManager.test.js
+++ b/tests/unit/battleManager.test.js
@@ -1,0 +1,24 @@
+import { BattleManager } from '../../src/managers/battleManager.js';
+import { EventManager } from '../../src/managers/eventManager.js';
+import { describe, test, assert } from '../helpers.js';
+
+describe('BattleManager', () => {
+    test('uses provided eventManager when valid', () => {
+        const game = {};
+        const em = new EventManager();
+        const bm = new BattleManager(game, em, {}, {}, {});
+        assert.strictEqual(bm.eventManager, em);
+    });
+
+    test('falls back to game.eventManager when provided eventManager is invalid', () => {
+        const game = { eventManager: new EventManager() };
+        const bm = new BattleManager(game, null, {}, {}, {});
+        assert.strictEqual(bm.eventManager, game.eventManager);
+    });
+
+    test('creates new instance when both provided and game eventManager are invalid', () => {
+        const game = {};
+        const bm = new BattleManager(game, null, {}, {}, {});
+        assert.ok(bm.eventManager instanceof EventManager, 'should create its own EventManager');
+    });
+});


### PR DESCRIPTION
## Summary
- make BattleManager prefer game's eventManager if provided one is invalid
- add unit tests for BattleManager fallback logic

## Testing
- `npm test` *(fails to run all tests due to TensorFlow warnings, but some tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_6860999adc908327ba89c3aed324caa4