### PR TITLE
Fix arena entry triggering regular combat

### DIFF
--- a/src/arena/arenaManager.js
+++ b/src/arena/arenaManager.js
@@ -67,6 +67,9 @@ class ArenaManager {
             this.game.movementManager.mapManager = this.game.mapManager;
         }
         this.game.clearAllUnits();
+        if (this.game.uiManager?.hidePanel) {
+            this.game.uiManager.hidePanel('squad-management-ui');
+        }
         console.log("\u2694\ufe0f \uc544\ub808\ub098\uc5d0 \uc624\uc2e0 \uac83\uc744 \ud658\uc601\ud569\ub2c8\ub2e4! AI \uc790\ub3d9 \ub300\ub825\uc744 \uc2dc\uc791\ud569\ub2c8\ub2e4.");
         this.game.showArenaMap();
         this.game.gameState.currentState = 'ARENA';

--- a/src/game.js
+++ b/src/game.js
@@ -888,6 +888,7 @@ export class Game {
 
         // 월드맵과 전투 상태 전환 이벤트 처리
         eventManager.subscribe('start_combat', (data) => {
+            if (gameState.currentState !== 'WORLD') return;
             console.log(`전투 준비! 상대 부대 규모: ${data.monsterParty.troopSize}`);
             gameState.currentState = 'FORMATION_SETUP';
             this.pendingMonsterParty = data.monsterParty;


### PR DESCRIPTION
## Summary
- guard start_combat handler so it only triggers in world map
- hide formation UI when starting the arena to avoid leftover UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860abbc4fb48327a26b95ae1ea52c3d