### PR TITLE
Apply map cleanup and start fixes

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -1345,7 +1345,10 @@ export class Game {
         } else if (this.gameState.currentState === "COMBAT") {
             this.combatEngine.render();
         } else if (this.gameState.currentState === "ARENA") {
-            this.arenaManager.render(this.layerManager.contexts, this.mapManager, this.assets);
+            // arenaManager.render 호출 방식을 패치에 맞게 수정
+            if (this.arenaManager) {
+                this.arenaManager.render(this.layerManager.contexts, this.mapManager, this.assets);
+            }
         }
         if (this.uiManager) this.uiManager.updateUI(this.gameState);
     }
@@ -1491,12 +1494,7 @@ export class Game {
     }
 
     loadMap(mapId) {
-        this.currentMapId = mapId;
-        console.log(`맵 로딩: ${mapId}`);
-        if (mapId === 'arena') {
-            this.arenaManager.start();
-        } else {
-            this.arenaManager.stop();
-        }
+        // 기존의 game.loadMap은 mapManager를 호출하는 역할만 하도록 단순화합니다.
+        this.mapManager.loadMap(mapId);
     }
 }

--- a/src/maps/mapManager.js
+++ b/src/maps/mapManager.js
@@ -19,16 +19,23 @@ export class MapManager {
         }
 
         console.log("이전 맵의 시스템을 정리합니다.");
+        // ArenaManager가 존재하면 비활성화하고 제거
+        if (this.game.arenaManager) {
+            this.game.arenaManager.stop();
+            this.game.arenaManager = null;
+            console.log('ArenaManager가 정리되었습니다.');
+        }
+        // BattleLog가 존재하면 파괴하고 제거
         if (this.game.battleLog) {
             this.game.battleLog.destroy();
             this.game.battleLog = null;
+            console.log('BattleLog가 정리되었습니다.');
         }
-        if (this.game.arenaManager) {
-            this.game.arenaManager = null;
-        }
+        // FishManager가 존재하면 중지하고 제거
         if (this.game.fishManager) {
             this.game.fishManager.stop();
             this.game.fishManager = null;
+            console.log('FishManager가 정리되었습니다.');
         }
 
         this.currentMapKey = mapKey;
@@ -46,8 +53,11 @@ export class MapManager {
 
         if (mapKey === 'arena') {
             this.setupArenaSystems();
+            // 아레나 매니저가 스스로 게임 상태를 변경하고 시작하므로 여기서 start()를 호출합니다.
+            if (this.game.arenaManager) this.game.arenaManager.start();
         } else if (mapKey === 'aquarium') {
             this.setupAquariumSystems();
+            this.game.gameState.currentState = 'WORLD'; // 수족관은 월드 상태로 간주
         }
 
         if (this.game.eventManager) {
@@ -59,7 +69,9 @@ export class MapManager {
 
     setupArenaSystems() {
         console.log("아레나 시스템 설정 중...");
-        this.game.arenaManager = new ArenaManager(this.game);
+        if (!this.game.arenaManager) {
+            this.game.arenaManager = new ArenaManager(this.game);
+        }
         if (this.game.arenaTensorFlowManager) {
             console.log('Arena TensorFlow Manager가 이미 활성화되어 있습니다.');
         } else {


### PR DESCRIPTION
## Summary
- reset per-map systems when switching maps
- ensure ArenaManager starts correctly via MapManager
- update render path to handle optional ArenaManager
- delegate map loading to MapManager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860b02ad3348327b91c5ff5fd1ff2d8