### PR TITLE
Introduce ArenaEngine

### DIFF
--- a/src/arena/arenaManager.js
+++ b/src/arena/arenaManager.js
@@ -72,7 +72,6 @@ class ArenaManager {
         }
         console.log("\u2694\ufe0f \uc544\ub808\ub098\uc5d0 \uc624\uc2e0 \uac83\uc744 \ud658\uc601\ud569\ub2c8\ub2e4! AI \uc790\ub3d9 \ub300\ub825\uc744 \uc2dc\uc791\ud569\ub2c8\ub2e4.");
         this.game.showArenaMap();
-        this.game.gameState.currentState = 'ARENA';
         this.nextRound();
     }
 
@@ -93,7 +92,6 @@ class ArenaManager {
             this.prevMapManager = null;
         }
         this.game.showWorldMap();
-        this.game.gameState.currentState = 'WORLD';
         console.log(`\ud83d\udc4b \uc544\ub808\ub098\ub97c \ub5a0\ub0a0\uae4c. \ucd1d ${this.roundCount} \ub77c\uc6b4\ub4dc\uc758 \ub370\uc774\ud130\uac00 \uae30\ub85d\ub418\uc5c8\uc2b5\ub2c8\ub2e4.`);
     }
 

--- a/src/engines/arenaEngine.js
+++ b/src/engines/arenaEngine.js
@@ -1,0 +1,69 @@
+import { ArenaManager } from '../arena/arenaManager.js';
+
+/**
+ * \uC544\uB808\uB098 \uAC8C\uC784 \uBAA8\uB4DC\uC758 \uBAA8\uB450\uB97C \uCD1D\uAD04\uD558\uB294 \uCD5C\uC0C1\uC704 \uC5D4\uC9C4\uC785\uB2C8\uB2E4.
+ * \uAC8C\uC784 \uC0C1\uD0DC \uAD00\uB9AC, \uC5C5\uB370\uC774\uD2B8 \uBC0F \uB80C\uB354\uB9C1 \uD638\uCD9C\uC744 \uB2F4\uB2F9\uD569\uB2C8\uB2E4.
+ */
+export class ArenaEngine {
+    constructor(game) {
+        this.game = game;
+        this.isActive = false;
+
+        // ArenaEngine\uC740 ArenaManager\uB97C \uC18C\uC720\uD558\uACE0 \uAD00\uB9AC\uD569\uB2C8\uB2E4.
+        this.arenaManager = new ArenaManager(this.game);
+    }
+
+    /**
+     * ArenaEngine\uC744 \uC2DC\uC791\uD558\uACE0 \uAC8C\uC784 \uC0C1\uD0DC\uB97C 'ARENA'\uB85C \uBCC0\uACBD\uD569\uB2C8\uB2E4.
+     */
+    start() {
+        if (this.isActive) return;
+        this.isActive = true;
+        this.game.gameState.currentState = 'ARENA';
+        console.log("\uD83D\uDE80 Arena Engine\uC774 \uC2DC\uC791\uB418\uC5C8\uC2B5\uB2C8\uB2E4.");
+
+        // \uc2e4\uc81c \uc544\ub808\ub098 \uACbd\uae30 \ud654\ub294 ArenaManager\uc5d0 \uc704\uc784\ud569\ub2c8\ub2e4.
+        this.arenaManager.start();
+    }
+
+    /**
+     * ArenaEngine\uC744 \uC911\uC9C0\uD558\uACE0 \uAC8C\uC784 \uC0C1\uD0DC\uB97C 'WORLD'\uB85C \ub418\ub2c8\uB2E4.
+     */
+    stop() {
+        if (!this.isActive) return;
+        this.isActive = false;
+
+        // ArenaManager\ub97c \uba3c\uc800 \uc911\uc9c0\uc2dc\ud0b5\ub2c8\ub2e4.
+        this.arenaManager.stop();
+        this.game.gameState.currentState = 'WORLD';
+        console.log("\uD83D\uDED1 Arena Engine\uC774 \uC911\uC9C0\uB418\uC5C8\uC2B5\uB2C8\uB2E4.");
+    }
+
+    /**
+     * \uC544\ub808\ub098 \uc0c1\ud0dc\uc77c \ub54c \ub9e4 \ud504\ub808\uc784 \ud638\uce38\ub420 \uc5c5\ub370\uc774\ud2b8 \ub85c\uc9c1\uc785\ub2c8\uB2E4.
+     * @param {number} deltaTime
+     */
+    update(deltaTime) {
+        if (!this.isActive) return;
+
+        // ArenaEngine\uc740 \ud544\uc694\ud55c \ud558\uc704 \uc5d4\uc9c4\ub4e4\uc744 \uc21c\uc11c\ub300\ub85c \uc5c5\ub370\uc774\ud2b8\ud569\ub2c8\uB2E4.
+        // 1. \uc804\ud22c \uacc4\uc0b0\uc740 CombatEngine\uc5d0 \uc704\uc784
+        this.game.combatEngine.update(deltaTime);
+        // 2. \ub77c\uc6b4\ub4dc \uad00\ub9ac \ub4f1 \uacbd\uae30 \ud654\ub294 ArenaManager\uc5d0 \uc704\uc784
+        this.arenaManager.update(deltaTime);
+    }
+
+    /**
+     * \uC544\ub808\ub098 \uc0c1\ud0dc\uc77c \ub54c \ub9e4 \ud504\ub808\uc784 \ud638\uce38\ub420 \ub80c\ub354\ub9c1 \ub85c\uc9c1\uc785\ub2c8\uB2E4.
+     */
+    render() {
+        if (!this.isActive) return;
+
+        // \ub80c\ub354\ub9c1\uc740 ArenaManager\ub97c \ud1b5\ud574 \ucc98\ub9ac\ud569\ub2c8\uB2E4.
+        this.arenaManager.render(
+            this.game.layerManager.contexts,
+            this.game.mapManager,
+            this.game.assets
+        );
+    }
+}

--- a/src/game.js
+++ b/src/game.js
@@ -38,7 +38,7 @@ import { rollOnTable } from './utils/random.js';
 import { getMonsterLootTable } from './data/tables.js';
 import { MicroEngine } from './micro/MicroEngine.js';
 import { MicroCombatManager } from './micro/MicroCombatManager.js';
-import { ArenaManager } from './arena/arenaManager.js';
+import { ArenaEngine } from './engines/arenaEngine.js';
 import { MicroItemAIManager } from './managers/microItemAIManager.js';
 import { BattleManager } from './managers/battleManager.js';
 import { BattleResultManager } from './managers/battleResultManager.js';
@@ -86,7 +86,7 @@ export class Game {
         this.aquarium = document.getElementById('aquarium');
         this.isPaused = false;
         this.units = [];
-        this.arenaManager = new ArenaManager(this);
+        this.arenaEngine = new ArenaEngine(this);
         this.currentMapId = null;
     }
 
@@ -1326,12 +1326,10 @@ export class Game {
             return;
         }
 
-        if (this.gameState.currentState === 'COMBAT' || this.gameState.currentState === 'ARENA') {
+        if (this.gameState.currentState === 'COMBAT') {
             this.combatEngine.update(deltaTime);
-        }
-
-        if (this.arenaManager && this.arenaManager.isActive) {
-            this.arenaManager.update(deltaTime);
+        } else if (this.gameState.currentState === 'ARENA') {
+            this.arenaEngine.update(deltaTime);
         }
     }
     render = () => {
@@ -1345,7 +1343,7 @@ export class Game {
         } else if (this.gameState.currentState === "COMBAT") {
             this.combatEngine.render();
         } else if (this.gameState.currentState === "ARENA") {
-            this.arenaManager.render(this.layerManager.contexts, this.mapManager, this.assets);
+            this.arenaEngine.render();
         }
         if (this.uiManager) this.uiManager.updateUI(this.gameState);
     }
@@ -1494,9 +1492,9 @@ export class Game {
         this.currentMapId = mapId;
         console.log(`맵 로딩: ${mapId}`);
         if (mapId === 'arena') {
-            this.arenaManager.start();
+            this.arenaEngine.start();
         } else {
-            this.arenaManager.stop();
+            this.arenaEngine.stop();
         }
     }
 }

--- a/src/maps/mapManager.js
+++ b/src/maps/mapManager.js
@@ -1,4 +1,4 @@
-import { ArenaManager } from '../arena/arenaManager.js';
+// ArenaEngine \uc0ac\uc6a9\uc744 \uc704\ud574 ArenaManager \uc778\ud130\ud398\uc774\uc2a4\ub97c \uc81c\uac70\ud569\ub2c8\uB2E4.
 import { FishManager } from '../fish/fishManager.js';
 import { BattleLog } from '../systems/battleLog.js';
 
@@ -23,8 +23,8 @@ export class MapManager {
             this.game.battleLog.destroy();
             this.game.battleLog = null;
         }
-        if (this.game.arenaManager) {
-            this.game.arenaManager = null;
+        if (this.game.arenaEngine && this.game.arenaEngine.isActive) {
+            this.game.arenaEngine.stop();
         }
         if (this.game.fishManager) {
             this.game.fishManager.stop();
@@ -45,9 +45,11 @@ export class MapManager {
         this.game.clearAllUnits();
 
         if (mapKey === 'arena') {
-            this.setupArenaSystems();
+            // ArenaEngine\uc744 \uc2dc\uc791\ud569\ub2c8\ub2e4.
+            this.game.arenaEngine.start();
         } else if (mapKey === 'aquarium') {
             this.setupAquariumSystems();
+            this.game.gameState.currentState = 'WORLD';
         }
 
         if (this.game.eventManager) {
@@ -58,13 +60,7 @@ export class MapManager {
     }
 
     setupArenaSystems() {
-        console.log("아레나 시스템 설정 중...");
-        this.game.arenaManager = new ArenaManager(this.game);
-        if (this.game.arenaTensorFlowManager) {
-            console.log('Arena TensorFlow Manager가 이미 활성화되어 있습니다.');
-        } else {
-            // 필요하다면 여기서 생성
-        }
+        // \uc774 \ud568\uc218\uc758 \ub0b4\uc6a9\uc740 loadMap \ub0b4\ub85c \ud569\uce58\ub418\uc5c8\uc73c\ubbc0\ub85c \ubd88\uc73c\uc2dc\uc9c0 \uc54a\uc74c\ub2e4.
     }
 
     setupAquariumSystems() {


### PR DESCRIPTION
## Summary
- manage Arena mode via new `ArenaEngine`
- integrate `ArenaEngine` with `Game` and `MapManager`
- cleanup `ArenaManager` state transitions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860bccdb8cc8327a03170e3b74e3028