### PR TITLE
Fix freeze when images not yet loaded

### DIFF
--- a/src/arena/Unit.js
+++ b/src/arena/Unit.js
@@ -1,14 +1,23 @@
 import { JOBS } from '../data/jobs.js';
 import { StatManager } from '../stats.js';
+import { isImageLoaded } from '../utils/imageUtils.js';
 
 class Unit {
-    constructor(id, team, jobId, position = { x: 0, y: 0 }, microItemAIManager = null) {
+    constructor(
+        id,
+        team,
+        jobId,
+        position = { x: 0, y: 0 },
+        microItemAIManager = null,
+        image = null
+    ) {
         this.id = id;
         this.team = team;
         this.jobId = jobId;
         this.x = position.x;
         this.y = position.y;
         this.radius = 20;
+        this.image = image;
 
         this.kills = 0;
         this.equipment = {};
@@ -131,10 +140,20 @@ class Unit {
 
     render(ctx) {
         ctx.save();
-        ctx.fillStyle = this.team === 'A' ? 'red' : 'blue';
-        ctx.beginPath();
-        ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
-        ctx.fill();
+        if (isImageLoaded(this.image)) {
+            ctx.drawImage(
+                this.image,
+                this.x - this.radius,
+                this.y - this.radius,
+                this.radius * 2,
+                this.radius * 2
+            );
+        } else {
+            ctx.fillStyle = this.team === 'A' ? 'red' : 'blue';
+            ctx.beginPath();
+            ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
+            ctx.fill();
+        }
         ctx.fillStyle = 'white';
         ctx.font = '12px Arial';
         ctx.textAlign = 'center';

--- a/src/arena/arenaManager.js
+++ b/src/arena/arenaManager.js
@@ -145,6 +145,7 @@ class ArenaManager {
             const id = (typeof crypto !== 'undefined' && crypto.randomUUID)
                 ? crypto.randomUUID()
                 : Math.random().toString(36).slice(2);
+            const image = this.game.assets?.[jobId] || null;
             const unit = new Unit(
                 id,
                 teamName,
@@ -153,7 +154,8 @@ class ArenaManager {
                     x: xMin + Math.random() * (xMax - xMin),
                     y: Math.random() * 600,
                 },
-                this.game.microItemAIManager
+                this.game.microItemAIManager,
+                image
             );
             unit.onAttack = ({ attacker, defender, damage }) => {
                 if (this.combatWorker) {

--- a/src/entities.js
+++ b/src/entities.js
@@ -2,6 +2,7 @@
 
 import { MeleeAI, RangedAI, PlayerCombatAI } from './ai.js';
 import { StatManager } from './stats.js';
+import { isImageLoaded } from './utils/imageUtils.js';
 
 class Entity {
     constructor(config) {
@@ -153,7 +154,7 @@ class Entity {
         ctx.scale(this.direction || 1, 1);
         if (this.statusEffects.isTwisted) {
             this.drawTwistedAnimation(ctx);
-        } else if (this.image) {
+        } else if (isImageLoaded(this.image)) {
             ctx.drawImage(this.image, -this.width / 2, -this.height, this.width, this.height);
         }
 
@@ -181,7 +182,7 @@ class Entity {
         const flip = (phase === 1 || phase === 2) ? -1 : 1;
         ctx.scale(flip, 1);
         const scaleX = 0.5;
-        if (this.image) {
+        if (isImageLoaded(this.image)) {
             ctx.drawImage(this.image, (-this.width * scaleX) / 2, -this.height, this.width * scaleX, this.height);
         }
         ctx.restore();
@@ -411,7 +412,7 @@ export class Item {
     }
 
     render(ctx) {
-        if (this.image) {
+        if (isImageLoaded(this.image)) {
             ctx.drawImage(this.image, this.x, this.y, this.width, this.height);
         }
     }
@@ -490,7 +491,7 @@ export class Projectile {
             ctx.globalCompositeOperation = this.blendMode;
         }
 
-        if (this.image) {
+        if (isImageLoaded(this.image)) {
             ctx.drawImage(this.image, this.x, this.y, this.width, this.height);
             ctx.translate(this.x + this.width / 2, this.y + this.height / 2);
             ctx.rotate(this.rotation);

--- a/src/managers/vfxManager.js
+++ b/src/managers/vfxManager.js
@@ -1,5 +1,6 @@
 import { ParticleEngine } from './vfx/ParticleEngine.js';
 import { TextPopupEngine } from './vfx/TextPopupEngine.js';
+import { isImageLoaded } from '../utils/imageUtils.js';
 
 export class VFXManager {
     constructor(eventManager = null, itemManager = null) {
@@ -533,8 +534,8 @@ export class VFXManager {
             image,
             x,
             y,
-            width: options.width || image.width,
-            height: options.height || image.height,
+            width: options.width || (isImageLoaded(image) ? image.width : 0),
+            height: options.height || (isImageLoaded(image) ? image.height : 0),
             duration: options.duration || 20,
             alpha: options.alpha || 1.0,
             fade: options.fade || 0.05,
@@ -784,7 +785,7 @@ export class VFXManager {
                 const alpha = effect.life / effect.duration;
                 ctx.save();
                 ctx.globalAlpha = alpha;
-                if (effect.image) {
+                if (isImageLoaded(effect.image)) {
                     const d = currentRadius * 2;
                     ctx.drawImage(effect.image, effect.x - currentRadius, effect.y - currentRadius, d, d);
                 } else {
@@ -800,7 +801,7 @@ export class VFXManager {
                 const currentX = startPos.x + (endPos.x - startPos.x) * progress;
                 const currentY = startPos.y + (endPos.y - startPos.y) * progress;
                 const arc = Math.sin(progress * Math.PI) * popHeight;
-                if (item.image && item.image.width) {
+                if (isImageLoaded(item.image)) {
                     ctx.drawImage(item.image, currentX, currentY - arc, item.width, item.height);
                 }
             } else if (effect.type === 'eject_item') {
@@ -809,16 +810,18 @@ export class VFXManager {
                 const currentX = effect.startPos.x + Math.cos(effect.angle) * currentDist;
                 const currentY = effect.startPos.y + Math.sin(effect.angle) * currentDist;
                 const arc = Math.sin(progress * Math.PI) * effect.height;
-                if (effect.image && effect.image.width) {
+                if (isImageLoaded(effect.image)) {
                     ctx.drawImage(effect.image, currentX, currentY - arc, effect.item.width, effect.item.height);
                 }
             } else if (effect.type === 'item_use') {
-                const w = effect.image.width * effect.scale;
-                const h = effect.image.height * effect.scale;
-                ctx.save();
-                ctx.globalAlpha = effect.alpha;
-                ctx.drawImage(effect.image, effect.x - w / 2, effect.y - h / 2, w, h);
-                ctx.restore();
+                if (isImageLoaded(effect.image)) {
+                    const w = effect.image.width * effect.scale;
+                    const h = effect.image.height * effect.scale;
+                    ctx.save();
+                    ctx.globalAlpha = effect.alpha;
+                    ctx.drawImage(effect.image, effect.x - w / 2, effect.y - h / 2, w, h);
+                    ctx.restore();
+                }
             } else if (effect.type === 'glow') {
                 const { x, y, radius } = effect;
                 const gradient = ctx.createRadialGradient(x, y, 0, x, y, radius);
@@ -833,25 +836,29 @@ export class VFXManager {
                 ctx.fill();
                 ctx.restore();
             } else if (effect.type === 'sprite') {
-                ctx.save();
-                ctx.globalCompositeOperation = effect.blendMode;
-                ctx.globalAlpha = effect.alpha;
-                ctx.drawImage(
-                    effect.image,
-                    effect.x - effect.width / 2,
-                    effect.y - effect.height / 2,
-                    effect.width,
-                    effect.height
-                );
-                ctx.restore();
+                if (isImageLoaded(effect.image)) {
+                    ctx.save();
+                    ctx.globalCompositeOperation = effect.blendMode;
+                    ctx.globalAlpha = effect.alpha;
+                    ctx.drawImage(
+                        effect.image,
+                        effect.x - effect.width / 2,
+                        effect.y - effect.height / 2,
+                        effect.width,
+                        effect.height
+                    );
+                    ctx.restore();
+                }
             } else if (effect.type === 'flash') {
                 const { entity } = effect;
-                ctx.save();
-                ctx.drawImage(entity.image, entity.x, entity.y, entity.width, entity.height);
-                ctx.globalCompositeOperation = 'source-atop';
-                ctx.fillStyle = effect.color;
-                ctx.fillRect(entity.x, entity.y, entity.width, entity.height);
-                ctx.restore();
+                if (isImageLoaded(entity.image)) {
+                    ctx.save();
+                    ctx.drawImage(entity.image, entity.x, entity.y, entity.width, entity.height);
+                    ctx.globalCompositeOperation = 'source-atop';
+                    ctx.fillStyle = effect.color;
+                    ctx.fillRect(entity.x, entity.y, entity.width, entity.height);
+                    ctx.restore();
+                }
             } else if (effect.type === 'armor_break') {
                 const { rect } = effect;
                 const progress = 1 - effect.life / effect.duration;
@@ -862,28 +869,30 @@ export class VFXManager {
                 const centerY = rect.y + rect.height / 2;
                 const moveAmount = progress * 20;
 
-                ctx.drawImage(
-                    effect.image,
-                    0,
-                    0,
-                    effect.image.width / 2,
-                    effect.image.height,
-                    centerX - rect.width / 2 - moveAmount,
-                    centerY - rect.height / 2,
-                    rect.width / 2,
-                    rect.height
-                );
-                ctx.drawImage(
-                    effect.image,
-                    effect.image.width / 2,
-                    0,
-                    effect.image.width / 2,
-                    effect.image.height,
-                    centerX + moveAmount,
-                    centerY - rect.height / 2,
-                    rect.width / 2,
-                    rect.height
-                );
+                if (isImageLoaded(effect.image)) {
+                    ctx.drawImage(
+                        effect.image,
+                        0,
+                        0,
+                        effect.image.width / 2,
+                        effect.image.height,
+                        centerX - rect.width / 2 - moveAmount,
+                        centerY - rect.height / 2,
+                        rect.width / 2,
+                        rect.height
+                    );
+                    ctx.drawImage(
+                        effect.image,
+                        effect.image.width / 2,
+                        0,
+                        effect.image.width / 2,
+                        effect.image.height,
+                        centerX + moveAmount,
+                        centerY - rect.height / 2,
+                        rect.width / 2,
+                        rect.height
+                    );
+                }
                 ctx.restore();
             } else if (effect.type === 'arrow_trail') {
                 const p = effect.projectile;
@@ -907,7 +916,9 @@ export class VFXManager {
                 ctx.translate(centerX, centerY);
                 ctx.globalCompositeOperation = 'lighter';
                 ctx.globalAlpha = shine;
-                ctx.drawImage(effect.image, -effect.image.width / 2, -effect.image.height / 2);
+                if (isImageLoaded(effect.image)) {
+                    ctx.drawImage(effect.image, -effect.image.width / 2, -effect.image.height / 2);
+                }
                 ctx.restore();
             }
         }

--- a/src/utils/imageUtils.js
+++ b/src/utils/imageUtils.js
@@ -1,0 +1,10 @@
+// src/utils/imageUtils.js
+
+/**
+ * Check whether an HTMLImageElement is fully loaded.
+ * @param {HTMLImageElement|null} img
+ * @returns {boolean} True if the image is loaded and has valid dimensions.
+ */
+export function isImageLoaded(img) {
+    return !!(img && img.complete && img.naturalWidth > 0 && img.naturalHeight > 0);
+}


### PR DESCRIPTION
## Summary
- avoid using unloaded images in entity & VFX rendering
- centralize image loaded check in `imageUtils.js`
- adjust rendering functions to skip drawing when images haven't loaded
- arena units use job-specific sprites when available and fall back to circles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860cca5ba048327ad225781718c5e9f