### PR TITLE
Enable multi-unit TensorFlow control

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
 
     <div id="aquarium" style="display: none;"></div>
     <div id="arena-tf-stats" class="ui-frame" style="display:none;"></div>
+    <div id="arena-tf-reward" class="ui-frame" style="display:none;"></div>
     <div id="arena-round-summary" class="ui-frame" style="display:none;"></div>
 
     <div id="ui-panel" class="ui-frame">

--- a/src/game.js
+++ b/src/game.js
@@ -76,6 +76,7 @@ import { BattleMemoryManager } from './managers/battleMemoryManager.js';
 import { JOBS } from './data/jobs.js';
 import { ArenaUIManager } from './managers/arenaUIManager.js';
 import { ArenaTensorFlowManager } from './managers/arenaTensorFlowManager.js';
+import { ArenaRewardManager } from './managers/arenaRewardManager.js';
 
 export class Game {
     constructor() {
@@ -160,6 +161,7 @@ export class Game {
         this.battleMemoryManager = new BattleMemoryManager(this.eventManager);
         this.arenaUIManager = new ArenaUIManager(this.eventManager);
         this.arenaTensorFlowManager = new ArenaTensorFlowManager(this.eventManager);
+        this.arenaRewardManager = new ArenaRewardManager(this.eventManager);
         this.tooltipManager = new TooltipManager();
         this.entityManager = new EntityManager(this.eventManager);
         this.groupManager = new GroupManager(this.eventManager, this.entityManager.getEntityById.bind(this.entityManager));

--- a/src/managers/arenaRewardManager.js
+++ b/src/managers/arenaRewardManager.js
@@ -1,0 +1,58 @@
+export class ArenaRewardManager {
+    constructor(eventManager) {
+        this.eventManager = eventManager;
+        this.score = 0;
+        this.lastPrediction = null;
+        this.tfUnits = [];
+        this.setup();
+    }
+
+    setup() {
+        if (!this.eventManager) return;
+        this.eventManager.subscribe('battle_prediction_made', d => {
+            this.lastPrediction = d?.prediction || null;
+        });
+        this.eventManager.subscribe('arena_round_start', d => this.onRoundStart(d));
+        this.eventManager.subscribe('arena_round_end', d => this.onRoundEnd(d));
+    }
+
+    onRoundStart({ units }) {
+        this.tfUnits = (units || []).filter(u => u.tfController);
+        const teamCounts = {};
+        for (const u of this.tfUnits) {
+            teamCounts[u.team] = (teamCounts[u.team] || 0) + 1;
+        }
+        if (Object.values(teamCounts).every(c => c >= 3)) {
+            this.score += 50; // rule 4
+        }
+        this.updateDisplay();
+    }
+
+    onRoundEnd({ winner, bestUnit, worstUnit }) {
+        if (winner && this.lastPrediction && winner === this.lastPrediction) {
+            this.score += 10; // rule 1
+        }
+        if (bestUnit?.tfController) {
+            this.score += 20; // rule 2
+        }
+        if (worstUnit?.tfController) {
+            this.score -= 5; // rule 3
+        }
+        const hopeless = this.tfUnits.length > 0 && this.tfUnits.every(u => u.kills === 0 && !u.isAlive());
+        if (hopeless) {
+            this.score -= 30; // rule 5
+        }
+        this.updateDisplay();
+        this.lastPrediction = null;
+        this.tfUnits = [];
+    }
+
+    updateDisplay() {
+        if (typeof document === 'undefined') return;
+        const el = document.getElementById('arena-tf-reward');
+        if (el) {
+            el.style.display = 'block';
+            el.textContent = `잘했어요 점수: ${this.score}`;
+        }
+    }
+}

--- a/src/managers/arenaTensorFlowManager.js
+++ b/src/managers/arenaTensorFlowManager.js
@@ -13,18 +13,20 @@ export class ArenaTensorFlowManager {
         this.controllers = [];
         const teams = {};
         for (const u of units) {
-            if (!teams[u.team]) teams[u.team] = u;
+            if (!teams[u.team]) teams[u.team] = [];
+            if (teams[u.team].length < 3) teams[u.team].push(u);
         }
         for (const team in teams) {
-            const unit = teams[team];
-            const controller = new TensorFlowController(tf);
-            unit.tfController = controller;
-            this.controllers.push({ unit, controller });
-            if (this.eventManager) {
-                this.eventManager.publish('arena_log', {
-                    eventType: 'tf_control_assigned',
-                    message: `TensorFlow가 ${unit.id}을(를) 조종합니다`
-                });
+            for (const unit of teams[team]) {
+                const controller = new TensorFlowController(tf);
+                unit.tfController = controller;
+                this.controllers.push({ unit, controller });
+                if (this.eventManager) {
+                    this.eventManager.publish('arena_log', {
+                        eventType: 'tf_control_assigned',
+                        message: `TensorFlow가 ${unit.id}을(를) 조종합니다`
+                    });
+                }
             }
         }
     }

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -50,6 +50,7 @@ import { BattlePredictionManager } from './battlePredictionManager.js';
 import { BattleMemoryManager } from './battleMemoryManager.js';
 import { ArenaUIManager } from './arenaUIManager.js';
 import { ArenaTensorFlowManager } from './arenaTensorFlowManager.js';
+import { ArenaRewardManager } from './arenaRewardManager.js';
 // DataRecorder is only needed in a Node.js environment so we lazy-load it
 let DataRecorder = null;
 if (typeof process !== 'undefined' && process.versions?.node) {
@@ -111,4 +112,5 @@ export {
     BattleMemoryManager,
     ArenaUIManager,
     ArenaTensorFlowManager,
+    ArenaRewardManager,
 };

--- a/style.css
+++ b/style.css
@@ -636,3 +636,13 @@ body, html {
     padding: 6px 10px;
     z-index: 1000;
 }
+
+#arena-tf-reward {
+    position: absolute;
+    bottom: 40px;
+    left: 10px;
+    color: white;
+    background: rgba(0,0,0,0.6);
+    padding: 6px 10px;
+    z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- let TensorFlow command 3 units per team in the arena
- track performance with new `ArenaRewardManager`
- show reward score in the UI
- expose the new manager in the managers index
- style the reward display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860d22fdda88327b93be93091260e11