### PR TITLE
Implement arena camera controls and unit scaling

### DIFF
--- a/src/arena/Unit.js
+++ b/src/arena/Unit.js
@@ -9,14 +9,16 @@ class Unit {
         jobId,
         position = { x: 0, y: 0 },
         microItemAIManager = null,
-        image = null
+        image = null,
+        radius = 20
     ) {
         this.id = id;
         this.team = team;
         this.jobId = jobId;
         this.x = position.x;
         this.y = position.y;
-        this.radius = 20;
+        // radius determines both the body circle and dotted sprite size
+        this.radius = radius;
         this.image = image;
 
         this.kills = 0;

--- a/src/arena/arenaManager.js
+++ b/src/arena/arenaManager.js
@@ -57,6 +57,14 @@ class ArenaManager {
         if (this.game.gameLoop) this.game.gameLoop.timeScale = 5;
         this.prevMapManager = this.game.mapManager;
         this.game.mapManager = new ArenaMapManager();
+        // reset camera for arena
+        if (this.game.gameState) {
+            this.game.gameState.camera = { x: 0, y: 0 };
+            this.game.gameState.zoomLevel = 1;
+        }
+        if (this.game.cameraDrag) {
+            this.game.cameraDrag.followPlayer = false;
+        }
         if (this.game.pathfindingManager) {
             this.game.pathfindingManager.mapManager = this.game.mapManager;
         }
@@ -155,7 +163,8 @@ class ArenaManager {
                     y: Math.random() * 600,
                 },
                 this.game.microItemAIManager,
-                image
+                image,
+                this.game.mapManager?.tileSize ? this.game.mapManager.tileSize / 2 : 20
             );
             unit.onAttack = ({ attacker, defender, damage }) => {
                 if (this.combatWorker) {


### PR DESCRIPTION
## Summary
- reset camera and zoom when Arena starts
- size Arena units using the map's tile size so images and circles match

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860d3a8c54c8327befb9ae6c6cb15d1