### PR TITLE
Add skill usage to arena units

### DIFF
--- a/src/arena/TensorFlowController.js
+++ b/src/arena/TensorFlowController.js
@@ -1,4 +1,5 @@
 import tfLoader from '../utils/tf-loader.js';
+import { SKILLS } from '../data/skills.js';
 
 export class TensorFlowController {
     constructor(tf = null) {
@@ -20,6 +21,22 @@ export class TensorFlowController {
         for (const e of enemies) {
             const d = Math.hypot(e.x - unit.x, e.y - unit.y);
             if (d < minD) { minD = d; nearest = e; }
+        }
+        // attempt skill usage
+        if (Array.isArray(unit.skills)) {
+            for (const id of unit.skills) {
+                const skill = SKILLS[id];
+                if (!skill) continue;
+                if ((unit.skillCooldowns[id] || 0) > 0) continue;
+                if (skill.tags?.includes('attack')) {
+                    const range = (skill.range || unit.attackRange) / 8;
+                    if (minD <= range) {
+                        return { type: 'skill', skillId: id, target: nearest };
+                    }
+                } else if (skill.id === 'heal' && unit.hp < unit.stats.get('maxHp')) {
+                    return { type: 'skill', skillId: id, target: unit };
+                }
+            }
         }
         if (minD <= unit.attackRange) {
             return { type: 'attack', target: nearest };

--- a/src/arena/arenaManager.js
+++ b/src/arena/arenaManager.js
@@ -3,6 +3,7 @@ import { fluctuationEngine } from '../managers/ai/FluctuationEngine.js';
 import { Unit } from './Unit.js';
 import { JOBS } from '../data/jobs.js';
 import { ITEMS } from '../data/items.js';
+import { SKILLS } from '../data/skills.js';
 import { WebGPUArenaRenderer } from '../renderers/webgpuArenaRenderer.js';
 import { ArenaMapManager } from '../arenaMap.js';
 
@@ -148,12 +149,14 @@ class ArenaManager {
 
     spawnRandomTeam(teamName, count, xMin, xMax) {
         const jobKeys = Object.keys(JOBS).filter(j => j !== 'fire_god');
+        const skillKeys = Object.keys(SKILLS);
         for (let i = 0; i < count; i++) {
             const jobId = jobKeys[Math.floor(Math.random() * jobKeys.length)];
             const id = (typeof crypto !== 'undefined' && crypto.randomUUID)
                 ? crypto.randomUUID()
                 : Math.random().toString(36).slice(2);
             const image = this.game.assets?.[jobId] || null;
+            const skillId = skillKeys[Math.floor(Math.random() * skillKeys.length)];
             const unit = new Unit(
                 id,
                 teamName,
@@ -164,8 +167,10 @@ class ArenaManager {
                 },
                 this.game.microItemAIManager,
                 image,
-                this.game.mapManager?.tileSize ? this.game.mapManager.tileSize / 2 : 20
+                this.game.mapManager?.tileSize ? this.game.mapManager.tileSize / 2 : 20,
+                [skillId]
             );
+            unit.skillCooldowns[skillId] = 0;
             unit.onAttack = ({ attacker, defender, damage }) => {
                 if (this.combatWorker) {
                     this.combatWorker.postMessage({ type: 'attack', data: { attackerId: attacker.id, defenderId: defender.id, attackPower: damage } });


### PR DESCRIPTION
## Summary
- arena units now have random skills and cooldowns
- TensorFlow controller considers skills when deciding actions
- Unit can execute skills and shows text when using them

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860e23620ec83278f864ba1c92bcd64