### PR TITLE
Fix arena freeze by throttling log rendering

### DIFF
--- a/src/managers/arenaUIManager.js
+++ b/src/managers/arenaUIManager.js
@@ -2,6 +2,8 @@ export class ArenaCombatLogManager {
     constructor(eventManager) {
         this.logs = [];
         this.logElement = document.getElementById('arena-log-content');
+        this.dirty = false;
+        this._scheduleRender = this._scheduleRender.bind(this);
         eventManager.subscribe('arena_log', data => {
             if (data && data.message) this.add(data.message);
         });
@@ -10,11 +12,21 @@ export class ArenaCombatLogManager {
     add(message) {
         this.logs.push(message);
         if (this.logs.length > 30) this.logs.shift();
-        this.render();
+        if (!this.dirty) {
+            this.dirty = true;
+            if (typeof window !== 'undefined') {
+                requestAnimationFrame(this._scheduleRender);
+            }
+        }
     }
 
     clear() {
         this.logs = [];
+        this.render();
+    }
+
+    _scheduleRender() {
+        this.dirty = false;
         this.render();
     }
 


### PR DESCRIPTION
## Summary
- throttle DOM updates in `ArenaCombatLogManager` by batching updates via `requestAnimationFrame`

## Testing
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860eb51825c8327b8ed43ec94365ab5