### PR TITLE
Implement aquarium spectator manager

### DIFF
--- a/config/gameSettings.js
+++ b/config/gameSettings.js
@@ -26,6 +26,8 @@ export const SETTINGS = {
     // Aquarium map uses a 3-lane layout with jungle maze by default.
     // Set this to false to revert to a standard dungeon layout.
     ENABLE_AQUARIUM_LANES: false,
+    // 자동 12vs12 전투를 감상하는 수족관 관람 모드 활성화 여부
+    ENABLE_AQUARIUM_SPECTATOR_MODE: false,
     // guideline markdown files will be loaded from this GitHub API path
     // example: 'user/repo/contents/guidelines?ref=main'
     // Remote markdown guidelines are fetched via the GitHub API.

--- a/src/game.js
+++ b/src/game.js
@@ -46,6 +46,7 @@ import { BattleResultManager } from './managers/battleResultManager.js';
 import { StatusEffectsManager } from './managers/statusEffectsManager.js';
 import { disarmWorkflow, armorBreakWorkflow } from './workflows.js';
 import { PossessionAIManager } from './managers/possessionAIManager.js';
+import { AquariumSpectatorManager } from './managers/aquariumSpectatorManager.js';
 import { Ghost } from './entities.js';
 import { TankerGhostAI, RangedGhostAI, SupporterGhostAI, CCGhostAI } from './ai.js';
 import { EMBLEMS } from './data/emblems.js';
@@ -545,6 +546,25 @@ export class Game {
         this.player = player;
         // 월드 엔진에서도 동일한 플레이어 데이터를 사용하도록 설정
         this.worldEngine.setPlayer(player);
+
+        if (SETTINGS.ENABLE_AQUARIUM_SPECTATOR_MODE) {
+            const enemyFormationManager = new FormationManager(5, 5, formationSpacing, 'RIGHT', formationAngle);
+            this.spectatorManager = new AquariumSpectatorManager({
+                eventManager: this.eventManager,
+                mapManager: this.mapManager,
+                formationManager: this.formationManager,
+                enemyFormationManager,
+                factory: this.factory,
+                entityManager: this.entityManager,
+                groupManager: this.groupManager,
+                mercenaryManager: this.mercenaryManager,
+                monsterManager: this.monsterManager,
+                assets,
+                playerGroupId: this.playerGroup.id,
+                enemyGroupId: this.monsterGroup.id
+            });
+            this.spectatorManager.start();
+        }
 
         // 초기 아이템 배치
         if (this.mapManager.name !== 'aquarium') {

--- a/src/managers/aquariumSpectatorManager.js
+++ b/src/managers/aquariumSpectatorManager.js
@@ -1,0 +1,146 @@
+// src/managers/aquariumSpectatorManager.js
+import { aquariumSpectatorWorkflow } from '../workflows.js';
+import { FormationManager } from './formationManager.js';
+import { EnemyFormationManager } from './enemyFormationManager.js';
+
+let nodeFS = null;
+if (typeof window === 'undefined') {
+    try {
+        nodeFS = await import('fs');
+    } catch (e) {
+        nodeFS = null;
+    }
+}
+
+export class AquariumSpectatorManager {
+    constructor(options) {
+        const {
+            eventManager,
+            mapManager,
+            formationManager,
+            enemyFormationManager,
+            factory,
+            entityManager,
+            groupManager,
+            mercenaryManager = null,
+            monsterManager = null,
+            assets = {},
+            playerGroupId = 'player_party',
+            enemyGroupId = 'dungeon_monsters',
+            diaryPath = 'aquarium_spectator_diary.json'
+        } = options;
+        this.eventManager = eventManager;
+        this.mapManager = mapManager;
+        this.formationManager = formationManager || new FormationManager(5,5,mapManager.tileSize*2);
+        this.enemyFormationManager = enemyFormationManager || new EnemyFormationManager(5,5,mapManager.tileSize*2);
+        this.factory = factory;
+        this.entityManager = entityManager;
+        this.groupManager = groupManager;
+        this.mercenaryManager = mercenaryManager;
+        this.monsterManager = monsterManager;
+        this.assets = assets;
+        this.playerGroupId = playerGroupId;
+        this.enemyGroupId = enemyGroupId;
+        this.diaryPath = diaryPath;
+        this.battleCount = 0;
+        this.diary = [];
+        this.currentBattle = null;
+        this.fs = nodeFS;
+    }
+
+    start() {
+        if (this.eventManager) {
+            this.eventManager.subscribe('battle_ended', r => this.onBattleEnded(r));
+        }
+        this.initUI();
+        this.startNewBattle();
+    }
+
+    initUI() {
+        if (typeof document === 'undefined') return;
+        this.infoElement = document.getElementById('aquariumSpectatorInfo');
+        if (!this.infoElement) {
+            this.infoElement = document.createElement('div');
+            this.infoElement.id = 'aquariumSpectatorInfo';
+            Object.assign(this.infoElement.style, {
+                position: 'absolute',
+                top: '10px',
+                right: '10px',
+                padding: '4px 8px',
+                background: 'rgba(0,0,0,0.5)',
+                color: 'white',
+                fontSize: '14px'
+            });
+            document.body.appendChild(this.infoElement);
+        }
+        this.updateUI();
+    }
+
+    updateUI() {
+        if (this.infoElement) {
+            this.infoElement.textContent = `Spectator Battle: ${this.battleCount + 1}`;
+        }
+    }
+
+    startNewBattle() {
+        this.groupManager?.removeGroup(this.playerGroupId);
+        this.groupManager?.removeGroup(this.enemyGroupId);
+        if (this.entityManager?.entities) {
+            for (const id of [...this.entityManager.entities.keys()]) {
+                if (id !== this.entityManager.player?.id) {
+                    this.entityManager.removeEntityById(id);
+                }
+            }
+        }
+        if (this.entityManager) {
+            this.entityManager.mercenaries = [];
+            this.entityManager.monsters = [];
+        }
+
+        const result = aquariumSpectatorWorkflow({
+            factory: this.factory,
+            mapManager: this.mapManager,
+            formationManager: this.formationManager,
+            enemyFormationManager: this.enemyFormationManager,
+            entityManager: this.entityManager,
+            groupManager: this.groupManager,
+            assets: this.assets,
+            playerGroupId: this.playerGroupId,
+            enemyGroupId: this.enemyGroupId,
+            eventManager: this.eventManager
+        });
+
+        if (this.entityManager) {
+            this.entityManager.init(this.entityManager.player, result.playerUnits, result.enemyUnits);
+        }
+        if (this.mercenaryManager) this.mercenaryManager.mercenaries = result.playerUnits;
+        if (this.monsterManager) this.monsterManager.monsters = result.enemyUnits;
+
+        this.currentBattle = result;
+        this.updateUI();
+    }
+
+    onBattleEnded(result) {
+        const diff = Math.abs(
+            (result.survivors?.player || []).length -
+            (result.survivors?.enemy || []).length
+        );
+        const entry = {
+            battleNumber: this.battleCount + 1,
+            winner: result.winner,
+            difference: diff,
+            playerUnits: (this.currentBattle?.playerUnits || []).map(u => ({ id: u.id, jobId: u.jobId })),
+            enemyUnits: (this.currentBattle?.enemyUnits || []).map(u => ({ id: u.id, jobId: u.jobId }))
+        };
+        this.diary.push(entry);
+        if (this.fs) {
+            try {
+                this.fs.writeFileSync(this.diaryPath, JSON.stringify(this.diary, null, 2));
+            } catch (e) {
+                console.error('[AquariumSpectatorManager] Failed to write diary', e);
+            }
+        }
+        this.battleCount++;
+        this.startNewBattle();
+    }
+}

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -32,6 +32,7 @@ import { EnemyFormationManager } from './enemyFormationManager.js';
 import { MetaAIManager } from './metaAIManager.js';
 import { WorldMapAIManager } from './worldMapAIManager.js';
 import { AIManager } from './AIManager.js';
+import { AquariumSpectatorManager } from './aquariumSpectatorManager.js';
 import { SynergyManager } from '../micro/SynergyManager.js';
 import { SpeechBubbleManager } from './speechBubbleManager.js';
 import { AuraManager } from './AuraManager.js';
@@ -113,4 +114,5 @@ export {
     ArenaUIManager,
     ArenaTensorFlowManager,
     ArenaRewardManager,
+    AquariumSpectatorManager,
 };

--- a/tests/unit/aquariumSpectatorManager.test.js
+++ b/tests/unit/aquariumSpectatorManager.test.js
@@ -1,0 +1,43 @@
+import { AquariumSpectatorManager } from '../../src/managers/aquariumSpectatorManager.js';
+import { EventManager } from '../../src/managers/eventManager.js';
+import { GroupManager } from '../../src/managers/groupManager.js';
+import { FormationManager } from '../../src/managers/formationManager.js';
+import { EnemyFormationManager } from '../../src/managers/enemyFormationManager.js';
+import { describe, test, assert } from '../helpers.js';
+
+class StubFactory {
+    constructor() { this.count = 0; }
+    create(type, cfg) {
+        return { id: `u${this.count++}`, jobId: cfg.jobId, groupId: cfg.groupId, x: cfg.x, y: cfg.y, tileSize: cfg.tileSize, hp: 10 };
+    }
+}
+class StubMap {
+    constructor(){ this.tileSize = 1; this.width = 10; this.height = 10; }
+    getRandomFloorPosition(){ return { x:0, y:0 }; }
+    getPlayerStartingPosition(){ return { x:0, y:0 }; }
+}
+
+describe('AquariumSpectatorManager', () => {
+    test('records battle count on battle end', () => {
+        const em = new EventManager();
+        const gm = new GroupManager(em);
+        const map = new StubMap();
+        const f = new FormationManager();
+        const ef = new EnemyFormationManager();
+        const factory = new StubFactory();
+        const entityManager = { entities: new Map(), removeEntityById(){}, init(){} };
+        const manager = new AquariumSpectatorManager({
+            eventManager: em,
+            mapManager: map,
+            formationManager: f,
+            enemyFormationManager: ef,
+            factory,
+            entityManager,
+            groupManager: gm
+        });
+        manager.start();
+        em.publish('battle_ended', { winner: 'player', survivors: { player: [], enemy: [] }});
+        assert.strictEqual(manager.battleCount, 1);
+        assert.strictEqual(manager.diary.length, 1);
+    });
+});

--- a/tests/unit/aquariumSpectatorWorkflow.test.js
+++ b/tests/unit/aquariumSpectatorWorkflow.test.js
@@ -1,0 +1,34 @@
+import { aquariumSpectatorWorkflow } from '../../src/workflows.js';
+import { CharacterFactory } from '../../src/factory.js';
+import { AquariumMapManager } from '../../src/aquariumMap.js';
+import { FormationManager } from '../../src/managers/formationManager.js';
+import { EnemyFormationManager } from '../../src/managers/enemyFormationManager.js';
+import { GroupManager } from '../../src/managers/groupManager.js';
+import { EventManager } from '../../src/managers/eventManager.js';
+import { describe, test, assert } from '../helpers.js';
+
+const assets = {};
+
+describe('Workflows', () => {
+  test('aquariumSpectatorWorkflow spawns 12 vs 12', () => {
+    const map = new AquariumMapManager();
+    const factory = new CharacterFactory(assets);
+    const formation = new FormationManager(5, 5, map.tileSize);
+    const enemyFormation = new EnemyFormationManager(5, 5, map.tileSize);
+    const groupManager = new GroupManager();
+    const ctx = {
+      factory,
+      mapManager: map,
+      formationManager: formation,
+      enemyFormationManager: enemyFormation,
+      entityManager: { addEntity() {} },
+      groupManager,
+      assets,
+      eventManager: new EventManager()
+    };
+
+    const result = aquariumSpectatorWorkflow(ctx);
+    assert.strictEqual(result.playerUnits.length, 12);
+    assert.strictEqual(result.enemyUnits.length, 12);
+  });
+});


### PR DESCRIPTION
## Summary
- add `AquariumSpectatorManager` to manage continuous random battles
- export manager via managers/index.js
- integrate spectator manager into game start
- test diary tracking in `AquariumSpectatorManager`

## Testing
- `npm test` *(fails: Cannot find module 'tests/config/gameSettings.js')*

------
https://chatgpt.com/codex/tasks/task_e_68610568796c8327833927b4fd219718