### PR TITLE
Fix spectator manager initialization bug

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -257,7 +257,8 @@ export class Game {
                 name !== 'SkillManager' &&
                 name !== 'ProjectileManager' &&
                 name !== 'SquadManager' &&
-                name !== 'DataRecorder'
+                name !== 'DataRecorder' &&
+                name !== 'AquariumSpectatorManager'
         );
         for (const managerName of otherManagerNames) {
             if (managerName === 'UIManager') {


### PR DESCRIPTION
## Summary
- prevent automatic initialization of `AquariumSpectatorManager` when loading other managers
- this stops a crash from missing `mapManager` during game start

## Testing
- `npm test` *(fails: Cannot find module '/workspace/2d-mount-blade/tests/config/gameSettings.js')*

------
https://chatgpt.com/codex/tasks/task_e_68610a64d5f08327b80b33442d00d8d8