### PR TITLE
Fix aquariumSpectatorWorkflow enemy registration

### DIFF
--- a/src/workflows.js
+++ b/src/workflows.js
@@ -139,6 +139,7 @@ export function aquariumSpectatorWorkflow(context) {
 
     const playerUnits = Array.from({ length: 12 }, () => makeMerc(playerGroupId));
     const enemyUnits = Array.from({ length: 12 }, () => makeMerc(enemyGroupId));
+    if (entityManager?.mercenaries) entityManager.mercenaries.push(...enemyUnits);
 
     const allMap = {};
     [...playerUnits, ...enemyUnits].forEach(m => { allMap[m.id] = m; });


### PR DESCRIPTION
## Summary
- ensure enemy units spawned in `aquariumSpectatorWorkflow` are stored in the entity manager

## Testing
- `npm test` *(fails: Cannot find module '/workspace/2d-mount-blade/tests/config/gameSettings.js')*

------
https://chatgpt.com/codex/tasks/task_e_68611a082d608327864e860bc962b8a1