### PR TITLE
Fix spectator mode AI registration

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -558,6 +558,7 @@ export class Game {
                 factory: this.factory,
                 entityManager: this.entityManager,
                 groupManager: this.groupManager,
+                metaAIManager: this.metaAIManager,
                 mercenaryManager: this.mercenaryManager,
                 monsterManager: this.monsterManager,
                 assets,

--- a/src/managers/aquariumSpectatorManager.js
+++ b/src/managers/aquariumSpectatorManager.js
@@ -22,6 +22,7 @@ export class AquariumSpectatorManager {
             factory,
             entityManager,
             groupManager,
+            metaAIManager = null,
             mercenaryManager = null,
             monsterManager = null,
             assets = {},
@@ -38,6 +39,7 @@ export class AquariumSpectatorManager {
         this.groupManager = groupManager;
         this.mercenaryManager = mercenaryManager;
         this.monsterManager = monsterManager;
+        this.metaAIManager = metaAIManager;
         this.assets = assets;
         this.playerGroupId = playerGroupId;
         this.enemyGroupId = enemyGroupId;
@@ -104,6 +106,7 @@ export class AquariumSpectatorManager {
             enemyFormationManager: this.enemyFormationManager,
             entityManager: this.entityManager,
             groupManager: this.groupManager,
+            metaAIManager: this.metaAIManager,
             assets: this.assets,
             playerGroupId: this.playerGroupId,
             enemyGroupId: this.enemyGroupId,

--- a/src/workflows.js
+++ b/src/workflows.js
@@ -113,6 +113,7 @@ export function aquariumSpectatorWorkflow(context) {
         enemyFormationManager,
         entityManager,
         groupManager,
+        metaAIManager,
         assets = {},
         playerGroupId = 'player_party',
         enemyGroupId = 'dungeon_monsters',
@@ -130,10 +131,14 @@ export function aquariumSpectatorWorkflow(context) {
             tileSize: mapManager.tileSize,
             groupId,
             jobId,
-            image: assets[jobId]
+            image: assets[jobId] || assets.mercenary
         });
         entityManager?.addEntity(merc);
         groupManager?.addMember(merc);
+        if (metaAIManager) {
+            const group = metaAIManager.groups[groupId] || metaAIManager.createGroup(groupId);
+            group.addMember(merc);
+        }
         return merc;
     };
 

--- a/tests/unit/aquariumSpectatorWorkflow.test.js
+++ b/tests/unit/aquariumSpectatorWorkflow.test.js
@@ -4,10 +4,13 @@ import { AquariumMapManager } from '../../src/aquariumMap.js';
 import { FormationManager } from '../../src/managers/formationManager.js';
 import { EnemyFormationManager } from '../../src/managers/enemyFormationManager.js';
 import { GroupManager } from '../../src/managers/groupManager.js';
+import { MetaAIManager } from '../../src/managers/metaAIManager.js';
 import { EventManager } from '../../src/managers/eventManager.js';
 import { describe, test, assert } from '../helpers.js';
 
 const assets = {};
+const playerGroupId = 'player_party';
+const enemyGroupId = 'dungeon_monsters';
 
 describe('Workflows', () => {
   test('aquariumSpectatorWorkflow spawns 12 vs 12', () => {
@@ -16,6 +19,7 @@ describe('Workflows', () => {
     const formation = new FormationManager(5, 5, map.tileSize);
     const enemyFormation = new EnemyFormationManager(5, 5, map.tileSize);
     const groupManager = new GroupManager();
+    const metaAI = new MetaAIManager(new EventManager());
     const ctx = {
       factory,
       mapManager: map,
@@ -23,6 +27,7 @@ describe('Workflows', () => {
       enemyFormationManager: enemyFormation,
       entityManager: { addEntity() {} },
       groupManager,
+      metaAIManager: metaAI,
       assets,
       eventManager: new EventManager()
     };
@@ -30,5 +35,7 @@ describe('Workflows', () => {
     const result = aquariumSpectatorWorkflow(ctx);
     assert.strictEqual(result.playerUnits.length, 12);
     assert.strictEqual(result.enemyUnits.length, 12);
+    assert.strictEqual(metaAI.groups[playerGroupId]?.members.length || 0, 12);
+    assert.strictEqual(metaAI.groups[enemyGroupId]?.members.length || 0, 12);
   });
 });


### PR DESCRIPTION
## Summary
- connect spectator workflow units to MetaAIManager
- pass MetaAIManager into AquariumSpectatorManager and Game
- provide default mercenary image in workflow
- ensure tests cover MetaAIManager group registration

## Testing
- `npm test` *(fails: Cannot find module '/workspace/2d-mount-blade/tests/config/gameSettings.js')*

------
https://chatgpt.com/codex/tasks/task_e_68611d7a3df48327be8f8b4a771d779d