### PR TITLE
Fix spectator mode cleanup

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -561,6 +561,8 @@ export class Game {
                 metaAIManager: this.metaAIManager,
                 mercenaryManager: this.mercenaryManager,
                 monsterManager: this.monsterManager,
+                projectileManager: this.projectileManager,
+                vfxManager: this.vfxManager,
                 assets,
                 playerGroupId: this.playerGroup.id,
                 enemyGroupId: this.monsterGroup.id

--- a/src/managers/aquariumSpectatorManager.js
+++ b/src/managers/aquariumSpectatorManager.js
@@ -25,6 +25,8 @@ export class AquariumSpectatorManager {
             metaAIManager = null,
             mercenaryManager = null,
             monsterManager = null,
+            projectileManager = null,
+            vfxManager = null,
             assets = {},
             playerGroupId = 'player_party',
             enemyGroupId = 'dungeon_monsters',
@@ -40,6 +42,8 @@ export class AquariumSpectatorManager {
         this.mercenaryManager = mercenaryManager;
         this.monsterManager = monsterManager;
         this.metaAIManager = metaAIManager;
+        this.projectileManager = projectileManager;
+        this.vfxManager = vfxManager;
         this.assets = assets;
         this.playerGroupId = playerGroupId;
         this.enemyGroupId = enemyGroupId;
@@ -89,6 +93,8 @@ export class AquariumSpectatorManager {
             clearInterval(this._interval);
             this._interval = null;
         }
+        this.vfxManager?.clear?.();
+        this.projectileManager?.clear?.();
         this.groupManager?.removeGroup(this.playerGroupId);
         this.groupManager?.removeGroup(this.enemyGroupId);
         if (this.entityManager?.entities) {

--- a/src/managers/projectileManager.js
+++ b/src/managers/projectileManager.js
@@ -121,4 +121,8 @@ export class ProjectileManager {
             proj.render(ctx);
         }
     }
+
+    clear() {
+        this.projectiles.length = 0;
+    }
 }

--- a/src/managers/vfx/ParticleEngine.js
+++ b/src/managers/vfx/ParticleEngine.js
@@ -147,5 +147,10 @@ export class ParticleEngine {
             p.render(ctx);
         }
     }
+
+    clear() {
+        this.emitters.length = 0;
+        this.particles.length = 0;
+    }
 }
 

--- a/src/managers/vfxManager.js
+++ b/src/managers/vfxManager.js
@@ -750,6 +750,12 @@ export class VFXManager {
 
     }
 
+    clear() {
+        this.effects.length = 0;
+        this.particleEngine.clear();
+        this.textPopupEngine.popups.length = 0;
+    }
+
     render(ctx) {
         for (const effect of this.effects) {
             if (effect.type === 'death_animation') {


### PR DESCRIPTION
## Summary
- ensure spectator battles reset VFX and projectiles between loops
- expose clearing helpers in VFXManager, ParticleEngine and ProjectileManager
- pass VFX and projectile managers to AquariumSpectatorManager

## Testing
- `npm test` *(fails: Cannot find module '/workspace/2d-mount-blade/tests/config/gameSettings.js')*

------
https://chatgpt.com/codex/tasks/task_e_686129cca58c832789a42df2ac5e83df