### PR TITLE
Add Amusement Park engine and manager

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,7 @@
                 <button id="save-game-btn">게임 저장</button>
                 <button id="toggle-autobattle-btn">자동 전투: OFF</button>
                 <button id="enter-arena-btn">아레나 진입</button>
+                <button id="enter-amusement-btn">놀이동산 입장</button>
                 <button id="random-loop-btn">랜덤 루프</button>
             </div>
         </div>

--- a/src/engines/amusementParkEngine.js
+++ b/src/engines/amusementParkEngine.js
@@ -1,0 +1,39 @@
+import { AmusementParkManager } from '../managers/amusementParkManager.js';
+
+export class AmusementParkEngine {
+    constructor(game) {
+        this.game = game;
+        this.isActive = false;
+        this.manager = new AmusementParkManager(game);
+    }
+
+    start() {
+        if (this.isActive) return;
+        this.isActive = true;
+        this.game.gameState.currentState = 'AMUSEMENT_PARK';
+        this.manager.start();
+    }
+
+    stop() {
+        if (!this.isActive) return;
+        this.isActive = false;
+        this.manager.stop();
+        this.game.gameState.currentState = 'WORLD';
+    }
+
+    update(dt) {
+        if (this.isActive) {
+            this.manager.update(dt);
+        }
+    }
+
+    render() {
+        if (this.isActive) {
+            this.manager.render(
+                this.game.layerManager.contexts,
+                this.game.mapManager,
+                this.game.assets
+            );
+        }
+    }
+}

--- a/src/game.js
+++ b/src/game.js
@@ -39,6 +39,7 @@ import { getMonsterLootTable } from './data/tables.js';
 import { MicroEngine } from './micro/MicroEngine.js';
 import { MicroCombatManager } from './micro/MicroCombatManager.js';
 import { ArenaEngine } from './engines/arenaEngine.js';
+import { AmusementParkEngine } from './engines/amusementParkEngine.js';
 import { MicroItemAIManager } from './managers/microItemAIManager.js';
 import { BattleManager } from './managers/battleManager.js';
 import { BattleResultManager } from './managers/battleResultManager.js';
@@ -89,6 +90,7 @@ export class Game {
         this.isPaused = false;
         this.units = [];
         this.arenaEngine = new ArenaEngine(this);
+        this.amusementParkEngine = new AmusementParkEngine(this);
         this.currentMapId = null;
     }
 
@@ -884,6 +886,13 @@ export class Game {
             };
         }
 
+        const amusementBtn = document.getElementById('enter-amusement-btn');
+        if (amusementBtn) {
+            amusementBtn.onclick = () => {
+                this.loadMap('amusement');
+            };
+        }
+
         const randomLoopBtn = document.getElementById('random-loop-btn');
         if (randomLoopBtn && this.spectatorManager) {
             randomLoopBtn.onclick = () => {
@@ -1526,8 +1535,13 @@ export class Game {
         console.log(`맵 로딩: ${mapId}`);
         if (mapId === 'arena') {
             this.arenaEngine.start();
+            this.amusementParkEngine.stop();
+        } else if (mapId === 'amusement') {
+            this.amusementParkEngine.start();
+            this.arenaEngine.stop();
         } else {
             this.arenaEngine.stop();
+            this.amusementParkEngine.stop();
         }
     }
 }

--- a/src/managers/amusementParkManager.js
+++ b/src/managers/amusementParkManager.js
@@ -1,0 +1,108 @@
+import { ArenaManager } from '../arena/arenaManager.js';
+import { FormationManager } from './formationManager.js';
+import { AquariumSpectatorManager } from './aquariumSpectatorManager.js';
+import { ProjectileManager } from './projectileManager.js';
+
+// Combines Arena combat with Aquarium spectator visuals
+export class AmusementParkManager extends ArenaManager {
+    constructor(game) {
+        super(game);
+        this.spectatorManager = null;
+        this.infoElement = null;
+    }
+
+    start() {
+        this.isActive = true;
+        if (this.game.gameLoop) this.game.gameLoop.timeScale = 5;
+        // keep current map (aquarium) without replacing
+        if (this.game.gameState) {
+            this.game.gameState.camera = { x: 0, y: 0 };
+            this.game.gameState.zoomLevel = 1;
+        }
+        if (this.game.cameraDrag) {
+            this.game.cameraDrag.followPlayer = false;
+        }
+        if (this.game.pathfindingManager) {
+            this.game.pathfindingManager.mapManager = this.game.mapManager;
+        }
+        if (this.game.motionManager) {
+            this.game.motionManager.mapManager = this.game.mapManager;
+        }
+        if (this.game.movementManager) {
+            this.game.movementManager.mapManager = this.game.mapManager;
+        }
+        this.projectileManager = new ProjectileManager(
+            this.game.eventManager,
+            this.game.assets,
+            this.game.vfxManager,
+            this.game.knockbackEngine
+        );
+        this.game.clearAllUnits();
+        if (this.game.uiManager?.hidePanel) {
+            this.game.uiManager.hidePanel('squad-management-ui');
+        }
+        this.spectatorManager = new AquariumSpectatorManager({
+            eventManager: this.game.eventManager,
+            mapManager: this.game.mapManager,
+            formationManager: this.game.formationManager,
+            enemyFormationManager: new FormationManager(5,5,this.game.mapManager.tileSize*2),
+            factory: this.game.factory,
+            entityManager: this.game.entityManager,
+            groupManager: this.game.groupManager,
+            metaAIManager: this.game.metaAIManager,
+            mercenaryManager: this.game.mercenaryManager,
+            monsterManager: this.game.monsterManager,
+            projectileManager: this.projectileManager,
+            vfxManager: this.game.vfxManager,
+            assets: this.game.assets,
+            playerGroupId: this.game.playerGroup?.id || 'player_party',
+            enemyGroupId: this.game.monsterGroup?.id || 'dungeon_monsters'
+        });
+        this.spectatorManager.initUI();
+        this._initSpectatorUI();
+        console.log('🎡 놀이동산 전투를 시작합니다!');
+        this.game.showArenaMap();
+        this.nextRound();
+    }
+
+    _initSpectatorUI() {
+        if (typeof document === 'undefined') return;
+        this.infoElement = document.getElementById('amusement-info');
+        if (!this.infoElement) {
+            this.infoElement = document.createElement('div');
+            this.infoElement.id = 'amusement-info';
+            Object.assign(this.infoElement.style, {
+                position: 'absolute',
+                top: '40px',
+                right: '10px',
+                padding: '4px 8px',
+                background: 'rgba(0,0,0,0.5)',
+                color: 'white',
+                fontSize: '14px'
+            });
+            document.body.appendChild(this.infoElement);
+        }
+        this.updateSpectatorUI(1);
+        this.game.eventManager?.subscribe('arena_round_end', d => {
+            this.updateSpectatorUI(d.round + 1);
+        });
+    }
+
+    updateSpectatorUI(round) {
+        if (this.infoElement) {
+            this.infoElement.textContent = `Amusement Round: ${round}`;
+        }
+    }
+
+    stop() {
+        super.stop();
+        if (this.infoElement) {
+            this.infoElement.remove();
+            this.infoElement = null;
+        }
+        if (this.spectatorManager && this.spectatorManager._interval) {
+            clearInterval(this.spectatorManager._interval);
+        }
+        this.spectatorManager = null;
+    }
+}

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -33,6 +33,7 @@ import { MetaAIManager } from './metaAIManager.js';
 import { WorldMapAIManager } from './worldMapAIManager.js';
 import { AIManager } from './AIManager.js';
 import { AquariumSpectatorManager } from './aquariumSpectatorManager.js';
+import { AmusementParkManager } from './amusementParkManager.js';
 import { SynergyManager } from '../micro/SynergyManager.js';
 import { SpeechBubbleManager } from './speechBubbleManager.js';
 import { AuraManager } from './AuraManager.js';
@@ -115,4 +116,5 @@ export {
     ArenaTensorFlowManager,
     ArenaRewardManager,
     AquariumSpectatorManager,
+    AmusementParkManager,
 };


### PR DESCRIPTION
## Summary
- introduce `AmusementParkManager` combining arena battles with aquarium spectator UI
- create `AmusementParkEngine`
- export manager in managers index
- hook up new engine in `Game` and add loadMap logic
- add UI button to enter the amusement park

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_68613197a59483278c859ca9e7c3a9ca