### PR TITLE
Disable arena sprites

### DIFF
--- a/src/arena/arenaManager.js
+++ b/src/arena/arenaManager.js
@@ -179,7 +179,8 @@ class ArenaManager {
             const id = (typeof crypto !== 'undefined' && crypto.randomUUID)
                 ? crypto.randomUUID()
                 : Math.random().toString(36).slice(2);
-            const image = this.game.assets?.[jobId] || null;
+            // Arena map에서는 유닛 이미지를 사용하지 않고 기본 원형으로 그립니다.
+            const image = null;
             const skillId = skillKeys[Math.floor(Math.random() * skillKeys.length)];
 
             let x, y, attempts = 0;


### PR DESCRIPTION
## Summary
- use circle rendering for arena units

## Testing
- `npm test` *(fails: Cannot find module '/workspace/2d-mount-blade/tests/config/gameSettings.js')*

------
https://chatgpt.com/codex/tasks/task_e_6861549cfa2c83279ff7337b2f10c06f