### PR TITLE
Add ProcessTerminationManager for cleanup

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -47,6 +47,7 @@ import { StatusEffectsManager } from './managers/statusEffectsManager.js';
 import { disarmWorkflow, armorBreakWorkflow } from './workflows.js';
 import { PossessionAIManager } from './managers/possessionAIManager.js';
 import { AquariumSpectatorManager } from './managers/aquariumSpectatorManager.js';
+import { ProcessTerminationManager } from './managers/processTerminationManager.js';
 import { Ghost } from './entities.js';
 import { TankerGhostAI, RangedGhostAI, SupporterGhostAI, CCGhostAI } from './ai.js';
 import { EMBLEMS } from './data/emblems.js';
@@ -156,6 +157,7 @@ export class Game {
 
         // === 1. 모든 매니저 및 시스템 생성 ===
         this.eventManager = new EventManager();
+        this.terminationManager = new ProcessTerminationManager(this.eventManager);
         this.arenaLogStorage = new ArenaLogStorage(this.eventManager);
         this.tfArenaVisualizer = new TFArenaVisualizer(this.arenaLogStorage);
         this.battlePredictionManager = new BattlePredictionManager(this.eventManager);
@@ -379,7 +381,10 @@ export class Game {
         this.guidelineLoader = new GuidelineLoader(SETTINGS.GUIDELINE_REPO_URL);
         this.guidelineLoader.load();
         if (SETTINGS.ENABLE_POSSESSION_SYSTEM) {
-            this.possessionAIManager = new PossessionAIManager(this.eventManager);
+            this.possessionAIManager = new PossessionAIManager(
+                this.eventManager,
+                this.terminationManager
+            );
         } else {
             this.possessionAIManager = null;
         }

--- a/src/managers/aquariumSpectatorManager.js
+++ b/src/managers/aquariumSpectatorManager.js
@@ -93,11 +93,6 @@ export class AquariumSpectatorManager {
             clearInterval(this._interval);
             this._interval = null;
         }
-        // Reset any lingering ghost possessions between battles
-        if (this.possessionAIManager) {
-            this.possessionAIManager.ghosts = [];
-            this.possessionAIManager.possessedEntities.clear();
-        }
         this.vfxManager?.clear?.();
         this.projectileManager?.clear?.();
         this.groupManager?.removeGroup(this.playerGroupId);

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -37,6 +37,7 @@ import { SynergyManager } from '../micro/SynergyManager.js';
 import { SpeechBubbleManager } from './speechBubbleManager.js';
 import { AuraManager } from './AuraManager.js';
 import { PossessionAIManager } from './possessionAIManager.js';
+import { ProcessTerminationManager } from './processTerminationManager.js';
 import { CombatDecisionEngine } from './ai/CombatDecisionEngine.js';
 import { FluctuationEngine } from './ai/FluctuationEngine.js';
 import { ReputationManager } from './ReputationManager.js';
@@ -115,4 +116,5 @@ export {
     ArenaTensorFlowManager,
     ArenaRewardManager,
     AquariumSpectatorManager,
+    ProcessTerminationManager,
 };

--- a/src/managers/possessionAIManager.js
+++ b/src/managers/possessionAIManager.js
@@ -3,7 +3,7 @@ import { SKILLS } from '../data/skills.js';
 import { FearAI, ConfusionAI, BerserkAI, CharmAI } from '../ai.js';
 
 export class PossessionAIManager {
-    constructor(eventManager) {
+    constructor(eventManager, terminationManager = null) {
         this.eventManager = eventManager;
         this.ghosts = [];
         this.possessedEntities = new Set();
@@ -15,6 +15,9 @@ export class PossessionAIManager {
             this.eventManager.subscribe('emblem_unequipped', ({ entity }) => {
                 this.removePossession(entity);
             });
+        }
+        if (terminationManager) {
+            terminationManager.register('battle_ended', () => this.reset());
         }
         console.log("[PossessionAIManager] Initialized");
     }
@@ -163,5 +166,14 @@ export class PossessionAIManager {
                 }
             }
         }
+    }
+
+    /**
+     * 매니저의 상태를 초기화하는 정리(cleanup) 메서드.
+     */
+    reset() {
+        this.ghosts = [];
+        this.possessedEntities.clear();
+        console.log('[PossessionAIManager] 상태가 깨끗하게 초기화되었습니다.');
     }
 }

--- a/src/managers/processTerminationManager.js
+++ b/src/managers/processTerminationManager.js
@@ -1,0 +1,51 @@
+/**
+ * 프로세스 종료 및 정리를 관리하는 매니저.
+ * 특정 이벤트가 발생했을 때 등록된 정리 작업들을 실행합니다.
+ */
+export class ProcessTerminationManager {
+    /**
+     * @param {object} eventManager - 게임의 이벤트 매니저 인스턴스
+     */
+    constructor(eventManager) {
+        if (!eventManager) {
+            throw new Error('ProcessTerminationManager는 EventManager 인스턴스가 필요합니다.');
+        }
+        this.eventManager = eventManager;
+        this.tasks = new Map(); // Key: eventName, Value: Array of cleanup functions
+    }
+
+    /**
+     * 특정 이벤트가 발생했을 때 실행할 정리 작업을 등록합니다.
+     * @param {string} eventName - 작업을 실행시킬 이벤트의 이름 (예: 'battle_ended')
+     * @param {function} task - 실행할 콜백 함수
+     */
+    register(eventName, task) {
+        // 해당 이벤트에 대한 작업 목록이 없으면 새로 생성하고 이벤트를 구독합니다.
+        if (!this.tasks.has(eventName)) {
+            this.tasks.set(eventName, []);
+            // 해당 이벤트가 발생하면 등록된 모든 작업을 실행하도록 리스너를 추가합니다.
+            this.eventManager.subscribe(eventName, () => this.executeTasks(eventName));
+        }
+        // 해당 이벤트의 작업 목록에 새로운 작업을 추가합니다.
+        this.tasks.get(eventName).push(task);
+        console.log(`[TerminationManager] '${eventName}' 이벤트에 대한 정리 작업이 등록되었습니다.`);
+    }
+
+    /**
+     * 특정 이벤트에 등록된 모든 작업을 실행합니다.
+     * @param {string} eventName - 실행할 이벤트의 이름
+     */
+    executeTasks(eventName) {
+        const tasksToRun = this.tasks.get(eventName);
+        if (tasksToRun && tasksToRun.length > 0) {
+            console.log(`[TerminationManager] '${eventName}' 이벤트 발생. ${tasksToRun.length}개의 정리 작업을 실행합니다.`);
+            for (const task of tasksToRun) {
+                try {
+                    task();
+                } catch (error) {
+                    console.error(`[TerminationManager] '${eventName}' 이벤트 작업 실행 중 오류 발생:`, error);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ProcessTerminationManager` to handle cleanup callbacks
- hook `PossessionAIManager` into `ProcessTerminationManager`
- create/reset method for `PossessionAIManager`
- integrate new manager inside `Game`
- simplify `AquariumSpectatorManager` startNewBattle
- export `ProcessTerminationManager` from managers index

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_686289a9eb508327a38d575dfab16697