### PR TITLE
Start game directly in aquarium mode

### DIFF
--- a/config/gameSettings.js
+++ b/config/gameSettings.js
@@ -28,6 +28,8 @@ export const SETTINGS = {
     ENABLE_AQUARIUM_LANES: false,
     // 자동 12vs12 전투를 감상하는 수족관 관람 모드 활성화 여부
     ENABLE_AQUARIUM_SPECTATOR_MODE: true,
+    // 게임 시작 시 월드맵 대신 수족관 맵을 불러와 관람 모드로 돌입
+    START_WITH_AQUARIUM: true,
     // guideline markdown files will be loaded from this GitHub API path
     // example: 'user/repo/contents/guidelines?ref=main'
     // Remote markdown guidelines are fetched via the GitHub API.

--- a/src/game.js
+++ b/src/game.js
@@ -912,7 +912,11 @@ export class Game {
         });
 
         this.setupEventListeners(assets, canvas);
-        this.showWorldMap();
+        if (SETTINGS.START_WITH_AQUARIUM) {
+            this.showBattleMap();
+        } else {
+            this.showWorldMap();
+        }
         this.gameLoop = new GameLoop(this.update, this.render);
         this.gameLoop.start();
     }


### PR DESCRIPTION
## Summary
- introduce `START_WITH_AQUARIUM` setting
- show the battle map at startup when this setting is enabled

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6862bd7f0e6c83279cc8418780dab9cd