### PR TITLE
Add idle world enemies and hostile merc parties

### DIFF
--- a/src/worldEngine.js
+++ b/src/worldEngine.js
@@ -147,16 +147,8 @@ export class WorldEngine {
     }
 
     handleEnemyTurn() {
-        for (const monster of this.monsters) {
-            if (!monster || this.movementEngine.isMoving(monster)) continue;
-
-            const nextStep = this.walkManager.getNextStep(monster, this.player, 2);
-
-            if (nextStep.x >= 0 && nextStep.x < this.worldWidth / this.tileSize &&
-                nextStep.y >= 0 && nextStep.y < this.worldHeight / this.tileSize) {
-                this.movementEngine.startMovement(monster, nextStep);
-            }
-        }
+        // 월드맵의 적들은 플레이어를 추격하지 않는다.
+        // 향후 AI 확장을 고려하여 턴 전환만 처리한다.
         this.turnManager.nextTurn();
     }
 

--- a/tests/integration/worldFlow.integration.test.js
+++ b/tests/integration/worldFlow.integration.test.js
@@ -10,7 +10,7 @@ import { EntityManager } from '../../src/managers/entityManager.js';
 // 통합 시나리오: 월드맵 -> 적군 접근 -> 충돌로 전투 시작 -> 타이머 종료 -> 결과 반영
 
 describe('World-Battle Flow Integration', () => {
-  test('enemy approaches, battle occurs and results reflect on world map', () => {
+  test('player initiates combat with stationary enemy and results reflect on world map', () => {
     const eventManager = new EventManager();
 
     const entityManager = new EntityManager(eventManager);
@@ -63,12 +63,21 @@ describe('World-Battle Flow Integration', () => {
       microEngine.update(31); // 타이머 만료로 전투 종료
     });
 
-    // --- 적의 턴: 플레이어에게 두 칸 다가옴 ---
+    // --- 적의 턴: 적은 이동하지 않음 ---
     world.turnManager.currentTurn = 'ENEMY';
     world.update(1);
-    assert.strictEqual(enemyCommander.tileX, 2);
+    assert.strictEqual(enemyCommander.tileX, 4);
 
-    // --- 플레이어 턴: 이동하여 충돌 유발 ---
+    // --- 플레이어 턴: 한 칸 이동 ---
+    game.inputHandler.keysPressed['ArrowRight'] = true;
+    world.update(1);
+    game.inputHandler.keysPressed = {};
+    assert.strictEqual(playerCommander.tileX, 3);
+
+    // --- 적의 턴: 여전히 이동하지 않음 ---
+    world.update(1);
+
+    // --- 플레이어 턴: 다시 이동하여 충돌 유발 ---
     game.inputHandler.keysPressed['ArrowRight'] = true;
     world.update(1);
     game.inputHandler.keysPressed = {};


### PR DESCRIPTION
## Summary
- make world enemies stop chasing the player
- generate a hostile mercenary party at game start
- update world battle flow test to reflect stationary enemies

## Testing
- `npm test` *(fails: Cannot find module '/workspace/2d-mount-blade/tests/config/gameSettings.js')*

------
https://chatgpt.com/codex/tasks/task_e_6862c131fe5483279dc23a029fdb8a1b