### PR TITLE
Implement WorldCombatManager

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -79,6 +79,7 @@ import { JOBS } from './data/jobs.js';
 import { ArenaUIManager } from './managers/arenaUIManager.js';
 import { ArenaTensorFlowManager } from './managers/arenaTensorFlowManager.js';
 import { ArenaRewardManager } from './managers/arenaRewardManager.js';
+import { WorldCombatManager } from './managers/worldCombatManager.js';
 
 export class Game {
     constructor() {
@@ -227,6 +228,7 @@ export class Game {
         this.worldEngine = new WorldEngine(this, assets, this.movementEngine, this.worldMapRenderManager);
         this.combatEngine = new CombatEngine(this);
         this.battleManager = new BattleManager(this, this.eventManager, this.groupManager, this.entityManager, this.factory);
+        this.worldCombatManager = new WorldCombatManager(this, this.eventManager, this.worldEngine);
 
         // --- GridRenderer 인스턴스 생성 ---
         // AquariumMapManager의 정보를 바탕으로 GridRenderer를 초기화합니다.
@@ -961,28 +963,7 @@ export class Game {
         const { eventManager, combatCalculator, monsterManager, mercenaryManager, mapManager, metaAIManager, pathfindingManager } = this;
         const gameState = this.gameState;
 
-        // 월드맵과 전투 상태 전환 이벤트 처리
-        eventManager.subscribe('start_combat', (data) => {
-            if (gameState.currentState !== 'WORLD') return;
-            console.log(`전투 시작! 상대 부대 규모: ${data.monsterParty.troopSize}`);
-            const origin = { x: gameState.player.x, y: gameState.player.y };
-            const entityMap = { [gameState.player.id]: gameState.player };
-            this.mercenaryManager.mercenaries.forEach(m => { entityMap[m.id] = m; });
-            this.formationManager.apply(origin, entityMap);
-            this.pendingMonsterParty = data.monsterParty;
-            gameState.currentState = 'COMBAT';
-            this.worldEngine.monsters.forEach(m => m.isActive = false);
-        });
-
-        eventManager.subscribe('end_combat', (result) => {
-            console.log(`전투 종료! 결과: ${result.outcome}`);
-            gameState.currentState = 'WORLD';
-            if (result.outcome === 'victory') {
-                this.worldEngine.monsters = this.worldEngine.monsters.filter(m => m.isActive === false);
-                alert('Victory!');
-            }
-            this.worldEngine.monsters.forEach(m => m.isActive = true);
-        });
+        // 전투 관련 로직은 WorldCombatManager가 처리한다
 
         // 공격 이벤트 처리
         eventManager.subscribe('entity_attack', (data) => {

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -52,6 +52,7 @@ import { BattleMemoryManager } from './battleMemoryManager.js';
 import { ArenaUIManager } from './arenaUIManager.js';
 import { ArenaTensorFlowManager } from './arenaTensorFlowManager.js';
 import { ArenaRewardManager } from './arenaRewardManager.js';
+import { WorldCombatManager } from './worldCombatManager.js';
 // DataRecorder is only needed in a Node.js environment so we lazy-load it
 let DataRecorder = null;
 if (typeof process !== 'undefined' && process.versions?.node) {
@@ -114,5 +115,6 @@ export {
     ArenaUIManager,
     ArenaTensorFlowManager,
     ArenaRewardManager,
+    WorldCombatManager,
     AquariumSpectatorManager,
 };

--- a/src/managers/worldCombatManager.js
+++ b/src/managers/worldCombatManager.js
@@ -1,0 +1,39 @@
+export class WorldCombatManager {
+    constructor(game, eventManager, worldEngine) {
+        this.game = game;
+        this.eventManager = eventManager;
+        this.worldEngine = worldEngine;
+        this.activeCommander = null;
+        if (this.eventManager) {
+            this.eventManager.subscribe('start_combat', data => this.onStartCombat(data));
+            this.eventManager.subscribe('end_combat', result => this.onEndCombat(result));
+        }
+        console.log('[WorldCombatManager] Initialized');
+    }
+
+    onStartCombat(data) {
+        if (!data) return;
+        if (this.game.gameState.currentState !== 'WORLD') return;
+        this.activeCommander = data.monsterParty || null;
+        const origin = { x: this.game.gameState.player.x, y: this.game.gameState.player.y };
+        const entityMap = { [this.game.gameState.player.id]: this.game.gameState.player };
+        this.game.mercenaryManager.mercenaries.forEach(m => { entityMap[m.id] = m; });
+        this.game.formationManager.apply(origin, entityMap);
+        if (this.activeCommander) this.activeCommander.isActive = false;
+        this.game.gameState.currentState = 'COMBAT';
+    }
+
+    onEndCombat(result) {
+        this.game.gameState.currentState = 'WORLD';
+        if (result?.outcome === 'victory' && this.activeCommander) {
+            const idx = this.worldEngine.monsters.indexOf(this.activeCommander);
+            if (idx !== -1) {
+                this.worldEngine.monsters.splice(idx, 1);
+            }
+        } else if (this.activeCommander) {
+            this.activeCommander.isActive = true;
+        }
+        this.worldEngine.monsters.forEach(m => m.isActive = true);
+        this.activeCommander = null;
+    }
+}


### PR DESCRIPTION
## Summary
- add `WorldCombatManager` to manage world map combat transitions
- export the new manager in managers index
- initialize it from `Game` and remove inline combat event logic

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND and TensorFlow initialization errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862c810317c83278226df1f6023174a