### PR TITLE
Fix duplicate WorldCombatManager initialization

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -261,7 +261,8 @@ export class Game {
                 name !== 'ProjectileManager' &&
                 name !== 'SquadManager' &&
                 name !== 'DataRecorder' &&
-                name !== 'AquariumSpectatorManager'
+                name !== 'AquariumSpectatorManager' &&
+                name !== 'WorldCombatManager'
         );
         for (const managerName of otherManagerNames) {
             if (managerName === 'UIManager') {


### PR DESCRIPTION
## Summary
- exclude `WorldCombatManager` from the generic manager initialization loop
  to avoid constructing it with the wrong arguments

## Testing
- `npm test --silent` *(fails: Cannot find module '/workspace/2d-mount-blade/tests/config/gameSettings.js')*

------
https://chatgpt.com/codex/tasks/task_e_6862caa1120483279c46dddc17e46b48