### PR TITLE
Fix world map combat end flow

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -973,16 +973,32 @@ export class Game {
             this.pendingMonsterParty = data.monsterParty;
             gameState.currentState = 'COMBAT';
             this.worldEngine.monsters.forEach(m => m.isActive = false);
+
+            // 전투를 실제로 시작하도록 이벤트를 발행한다.
+            const defender = data.monsterParty.entity || data.monsterParty;
+            this.eventManager.publish('combat_started', {
+                attacker: gameState.player,
+                defender
+            });
         });
 
         eventManager.subscribe('end_combat', (result) => {
             console.log(`전투 종료! 결과: ${result.outcome}`);
             gameState.currentState = 'WORLD';
             if (result.outcome === 'victory') {
-                this.worldEngine.monsters = this.worldEngine.monsters.filter(m => m.isActive === false);
+                if (this.pendingMonsterParty) {
+                    const defeatedId = this.pendingMonsterParty.id;
+                    this.worldEngine.monsters = this.worldEngine.monsters.filter(m => m.id !== defeatedId);
+                    this.pendingMonsterParty = null;
+                }
                 alert('Victory!');
             }
             this.worldEngine.monsters.forEach(m => m.isActive = true);
+
+            // 월드맵 화면으로 복귀한다.
+            if (typeof this.showWorldMap === 'function') {
+                this.showWorldMap();
+            }
         });
 
         // 공격 이벤트 처리


### PR DESCRIPTION
## Summary
- fire `combat_started` when a world encounter triggers
- remove defeated monster when combat ends
- show the world map again after combat ends

## Testing
- `npm test` *(fails: Cannot find module '/workspace/2d-mount-blade/tests/config/gameSettings.js')*

------
https://chatgpt.com/codex/tasks/task_e_6862d108c04083279d946d35f385c2dc