### PR TITLE
Refactor game startup to initializer module

### DIFF
--- a/src/core/CameraController.js
+++ b/src/core/CameraController.js
@@ -1,0 +1,43 @@
+export class CameraController {
+  constructor(game) {
+    this.game = game;
+    this.cameraDrag = game.cameraDrag || {isDragging:false, dragStart:{x:0,y:0}, cameraStart:{x:0,y:0}, followPlayer:true};
+  }
+
+  startDragCamera(screenX, screenY) {
+    const { cameraDrag, gameState } = this.game;
+    cameraDrag.isDragging = true;
+    cameraDrag.followPlayer = false;
+    cameraDrag.dragStart.x = screenX;
+    cameraDrag.dragStart.y = screenY;
+    cameraDrag.cameraStart.x = gameState.camera.x;
+    cameraDrag.cameraStart.y = gameState.camera.y;
+  }
+
+  dragCamera(screenX, screenY) {
+    const { cameraDrag, gameState, layerManager, mapManager } = this.game;
+    if (!cameraDrag.isDragging) return;
+    const zoom = gameState.zoomLevel || 1;
+    const deltaX = (screenX - cameraDrag.dragStart.x) / zoom;
+    const deltaY = (screenY - cameraDrag.dragStart.y) / zoom;
+    gameState.camera.x = cameraDrag.cameraStart.x - deltaX;
+    gameState.camera.y = cameraDrag.cameraStart.y - deltaY;
+    const canvas = layerManager.layers.mapBase;
+    const mapPixelWidth = mapManager.width * mapManager.tileSize;
+    const mapPixelHeight = mapManager.height * mapManager.tileSize;
+    gameState.camera.x = Math.max(0, Math.min(gameState.camera.x, mapPixelWidth - canvas.width / zoom));
+    gameState.camera.y = Math.max(0, Math.min(gameState.camera.y, mapPixelHeight - canvas.height / zoom));
+  }
+
+  endDragCamera() {
+    this.game.cameraDrag.isDragging = false;
+  }
+
+  handleCameraReset() {
+    const { cameraDrag, inputHandler } = this.game;
+    if (!cameraDrag.followPlayer && Object.keys(inputHandler.keysPressed).length > 0) {
+      cameraDrag.followPlayer = true;
+      cameraDrag.isDragging = false;
+    }
+  }
+}

--- a/src/core/EventBinder.js
+++ b/src/core/EventBinder.js
@@ -1,0 +1,5 @@
+export class EventBinder {
+  static bindAll(game) {
+    game.setupEventListeners(game.assets, game.layerManager?.layers?.mapBase);
+  }
+}

--- a/src/core/GameInitializer.js
+++ b/src/core/GameInitializer.js
@@ -1,0 +1,61 @@
+import { AssetLoader } from '../assetLoader.js';
+
+export class GameInitializer {
+  constructor(game) {
+    this.game = game;
+    this.loader = new AssetLoader();
+  }
+
+  start() {
+    const l = this.loader;
+    l.loadImage('player', 'assets/player.png');
+    l.loadImage('monster', 'assets/monster.png');
+    l.loadImage('epic_monster', 'assets/epic_monster.png');
+    l.loadImage('warrior', 'assets/images/warrior.png');
+    l.loadImage('archer', 'assets/images/archer.png');
+    l.loadImage('healer', 'assets/images/healer.png');
+    l.loadImage('wizard', 'assets/images/wizard.png');
+    l.loadImage('summoner', 'assets/images/summoner.png');
+    l.loadImage('bard', 'assets/images/bard.png');
+    l.loadImage('fire_god', 'assets/images/fire-god.png');
+    l.loadImage('mercenary', 'assets/images/warrior.png');
+    l.loadImage('floor', 'assets/floor.png');
+    l.loadImage('wall', 'assets/wall.png');
+    l.loadImage('gold', 'assets/gold.png');
+    l.loadImage('potion', 'assets/potion.png');
+    l.loadImage('sword', 'assets/images/shortsword.png');
+    l.loadWeaponImages();
+    l.loadImage('shield', 'assets/images/shield.png');
+    l.loadImage('bow', 'assets/images/bow.png');
+    l.loadImage('arrow', 'assets/images/arrow.png');
+    l.loadImage('leather_armor', 'assets/images/leatherarmor.png');
+    l.loadImage('plate-armor', 'assets/images/plate-armor.png');
+    l.loadImage('iron-helmet', 'assets/images/iron-helmet.png');
+    l.loadImage('iron-gauntlets', 'assets/images/iron-gauntlets.png');
+    l.loadImage('iron-boots', 'assets/images/iron-boots.png');
+    l.loadImage('violin-bow', 'assets/images/violin-bow.png');
+    l.loadImage('skeleton', 'assets/images/skeleton.png');
+    l.loadImage('pet-fox', 'assets/images/pet-fox.png');
+    l.loadImage('guardian-hymn-effect', 'assets/images/Guardian Hymn-effect.png');
+    l.loadImage('courage-hymn-effect', 'assets/images/Courage Hymn-effect.png');
+    l.loadImage('fire-ball', 'assets/images/fire-ball.png');
+    l.loadImage('ice-ball', 'assets/images/ice-ball-effect.png');
+    l.loadImage('strike-effect', 'assets/images/strike-effect.png');
+    l.loadImage('healing-effect', 'assets/images/healing-effect.png');
+    l.loadImage('purify-effect', 'assets/images/purify-effect.png');
+    l.loadImage('corpse', 'assets/images/corpse.png');
+    l.loadImage('parasite', 'assets/images/parasite.png');
+    l.loadImage('leech', 'assets/images/parasite.png');
+    l.loadImage('worm', 'assets/images/parasite.png');
+    l.loadImage('world-tile', 'assets/images/world-tile.png');
+    l.loadImage('sea-tile', 'assets/images/sea-tile.png');
+    l.loadImage('talisman1', 'assets/images/talisman-1.png');
+    l.loadImage('talisman2', 'assets/images/talisman-2.png');
+    l.loadEmblemImages();
+    l.loadVfxImages();
+
+    l.onReady((assets) => {
+      this.game.init(assets);
+    });
+  }
+}

--- a/src/engines/CombatEngine.js
+++ b/src/engines/CombatEngine.js
@@ -9,7 +9,7 @@ export class CombatEngine {
     update(deltaTime) {
         const game = this.game;
 
-        game.handleCameraReset();
+        game.cameraController.handleCameraReset();
 
         const { gameState, mercenaryManager, monsterManager, itemManager, mapManager, inputHandler, effectManager, turnManager, metaAIManager, eventManager, pathfindingManager, microEngine, microItemAIManager } = game;
         if (gameState.isPaused || gameState.isGameOver) return;


### PR DESCRIPTION
## Summary
- add core modules for initialization, event binding and camera control
- delegate asset loading to `GameInitializer`
- centralize event subscription with `EventBinder`
- manage camera logic via `CameraController`
- adjust game and combat engine to use new helpers

## Testing
- `npm test` *(fails: Cannot find module and TensorFlow init errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862d7abedb88327867612d64101080f