### PR TITLE
Fix damage handler for arena units

### DIFF
--- a/src/arena/Unit.js
+++ b/src/arena/Unit.js
@@ -63,7 +63,7 @@ class Unit {
 
         if (this.eventManager) {
             this._damageHandler = (data) => {
-                if (data.attacker === this && this.eventManager) {
+                if (data.attacker === this) {
                     this.eventManager.publish('arena_log', {
                         eventType: 'attack',
                         attackerId: data.attacker.id,
@@ -71,18 +71,6 @@ class Unit {
                         damage: data.damage,
                         message: `${data.attacker.id} -> ${data.defender.id} (${data.damage})`
                     });
-                }
-                if (data.defender === this) {
-                    const prevHp = this.hp;
-                    this.hp = Math.max(0, this.hp - data.damage);
-                    if (prevHp > 0 && this.hp <= 0 && data.attacker) {
-                        data.attacker.kills++;
-                        this.eventManager.publish('arena_log', {
-                            eventType: 'unit_death',
-                            unitId: this.id,
-                            message: `${this.id} 사망`
-                        });
-                    }
                 }
             };
             this.eventManager.subscribe('damage_calculated', this._damageHandler);
@@ -144,6 +132,10 @@ class Unit {
 
     isAlive() {
         return this.hp > 0;
+    }
+
+    takeDamage(amount) {
+        this.hp = Math.max(0, this.hp - amount);
     }
 
     update(deltaTime, units) {


### PR DESCRIPTION
## Summary
- avoid applying damage twice when handling events
- add `takeDamage` method for arena units to unify API
- streamline damage event logging

## Testing
- `node run-tests.mjs` *(fails: Cannot find module 'tests/config/gameSettings.js')*

------
https://chatgpt.com/codex/tasks/task_e_6862dc3c025883279abf1b126f3b084b