### PR TITLE
Introduce EntityDeathWorkflow

### DIFF
--- a/src/workflows/entityDeathWorkflow.js
+++ b/src/workflows/entityDeathWorkflow.js
@@ -1,0 +1,92 @@
+import { Item } from '../entities.js';
+
+export class EntityDeathWorkflow {
+    constructor(context) {
+        this.eventManager = context.eventManager;
+        this.vfxManager = context.vfxManager;
+        this.itemManager = context.itemManager;
+        this.monsterManager = context.monsterManager;
+        this.mapManager = context.mapManager;
+        this.gameState = context.gameState;
+        this.assets = context.assets || {};
+        this.findEmptyTile = context.findEmptyTile;
+        this.rng = context.rng || Math.random;
+    }
+
+    /**
+     * Execute death handling for an entity.
+     * @param {object} attacker
+     * @param {object} victim
+     */
+    execute(attacker, victim) {
+        const { eventManager, vfxManager, itemManager, mapManager, assets,
+                monsterManager, gameState } = this;
+        if (!victim) return;
+
+        victim.isDying = true;
+        if (vfxManager && typeof vfxManager.addDeathAnimation === 'function') {
+            vfxManager.addDeathAnimation(victim, 'explode');
+        }
+
+        eventManager?.publish('log', { message: `${victim.constructor.name}\uAC00 \uC4F0\uB7EC\uC9C4\uB2E4`, color: 'red' });
+
+        if (victim.unitType === 'monster') {
+            eventManager?.publish('monster_defeated', { monster: victim, attacker });
+            // drop loot from victim inventory
+            const dropPool = [];
+            if (Array.isArray(victim.consumables)) dropPool.push(...victim.consumables);
+            if (victim.equipment) {
+                for (const slot in victim.equipment) {
+                    const it = victim.equipment[slot];
+                    if (it) dropPool.push(it);
+                }
+            }
+            const dropCount = Math.min(dropPool.length, Math.floor(this.rng() * 6));
+            for (let i = 0; i < dropCount; i++) {
+                const idx = Math.floor(this.rng() * dropPool.length);
+                const item = dropPool.splice(idx, 1)[0];
+                const startPos = { x: victim.x, y: victim.y };
+                const endPos = this.findEmptyTile ? (this.findEmptyTile(victim.x, victim.y) || startPos) : startPos;
+                item.x = endPos.x;
+                item.y = endPos.y;
+                itemManager?.addItem(item);
+                if (vfxManager && typeof vfxManager.addItemPopAnimation === 'function') {
+                    vfxManager.addItemPopAnimation(item, startPos, endPos);
+                }
+            }
+        }
+
+        if (!victim.isFriendly && (attacker?.isPlayer || attacker?.isFriendly)) {
+            if (attacker.isPlayer) {
+                eventManager?.publish('exp_gained', { player: attacker, exp: victim.expValue });
+            } else if (attacker.isFriendly) {
+                const sharedExp = victim.expValue / 2;
+                eventManager?.publish('exp_gained', { player: attacker, exp: sharedExp });
+                eventManager?.publish('exp_gained', { player: gameState.player, exp: sharedExp });
+            }
+        }
+
+        if (victim.unitType === 'monster' && assets.corpse) {
+            const corpse = new Item(
+                victim.x,
+                victim.y,
+                mapManager.tileSize,
+                'corpse',
+                assets.corpse
+            );
+            corpse.bobbingSpeed = 0;
+            corpse.bobbingAmount = 0;
+            corpse.baseY = victim.y;
+            itemManager?.addItem(corpse);
+        }
+
+        if (victim.unitType === 'monster' && monsterManager) {
+            const remaining = monsterManager.monsters.filter(m => m.hp > 0 && !m.isDying && m !== victim);
+            if (remaining.length === 0) {
+                eventManager?.publish('log', { message: 'victory', color: 'green' });
+                eventManager?.publish('end_combat', { outcome: 'victory' });
+            }
+        }
+    }
+}
+

--- a/tests/unit/entityDeathWorkflow.test.js
+++ b/tests/unit/entityDeathWorkflow.test.js
@@ -1,0 +1,39 @@
+import { EntityDeathWorkflow } from '../../src/workflows/entityDeathWorkflow.js';
+import { EventManager } from '../../src/managers/eventManager.js';
+import { describe, test, assert } from '../helpers.js';
+
+class StubVfx {
+  addDeathAnimation() {}
+  addItemPopAnimation() {}
+}
+class StubItemManager {
+  constructor() { this.items = []; }
+  addItem(item) { this.items.push(item); }
+}
+
+describe('Workflows', () => {
+  test('EntityDeathWorkflow awards exp and spawns corpse', () => {
+    const eventManager = new EventManager();
+    const vfx = new StubVfx();
+    const itemManager = new StubItemManager();
+    const mapManager = { tileSize: 32 };
+    const monsterManager = { monsters: [] };
+    const gameState = { player: { } };
+    const assets = { corpse: {}};
+    const workflow = new EntityDeathWorkflow({ eventManager, vfxManager: vfx, itemManager, mapManager, monsterManager, gameState, assets, findEmptyTile: () => ({x:0,y:0}) });
+
+    const attacker = { isPlayer: true, isFriendly: true, stats: { addExp(exp){ attacker.gained = exp; } } };
+    const victim = { id:'m1', unitType:'monster', isFriendly:false, expValue:5, x:0, y:0 };
+    monsterManager.monsters.push(victim);
+
+    let victory = false;
+    eventManager.subscribe('end_combat', () => { victory = true; });
+
+    workflow.execute(attacker, victim);
+
+    assert.strictEqual(attacker.gained, 5);
+    assert.strictEqual(itemManager.items.length, 1);
+    assert.ok(victory);
+  });
+});
+


### PR DESCRIPTION
## Summary
- extend WorkflowManager usage by adding an `EntityDeathWorkflow`
- register new workflow in `Game` initialization
- simplify `entity_death` event handling to trigger the workflow
- expose managers through `engineContext` for workflow access
- test `EntityDeathWorkflow` logic

## Testing
- `node run-tests.mjs` *(fails: Cannot find module '/workspace/2d-mount-blade/tests/config/gameSettings.js')*

------
https://chatgpt.com/codex/tasks/task_e_6862e0ce49488327b574acd9bc3a82d4