### PR TITLE
Add commander and battlefield map classes

### DIFF
--- a/src/battlefieldMap.js
+++ b/src/battlefieldMap.js
@@ -1,0 +1,35 @@
+import { MapManager } from './map.js';
+
+/**
+ * 넓고 사방이 벽으로 둘러싸인 전장 맵을 생성하는 매니저입니다.
+ * 기본 MapManager의 미로 생성 로직을 오버라이드하여
+ * 단순한 전장 형태를 제공합니다.
+ */
+export class BattlefieldMapManager extends MapManager {
+    constructor(seed) {
+        super(seed);
+    }
+
+    /**
+     * 가장자리는 벽, 내부는 바닥인 단순 전장을 생성합니다.
+     * @override
+     */
+    _generateMaze() {
+        this.width = 50;
+        this.height = 40;
+
+        const map = Array.from({ length: this.height }, () =>
+            Array(this.width).fill(this.tileTypes.FLOOR)
+        );
+
+        for (let x = 0; x < this.width; x++) {
+            map[0][x] = this.tileTypes.WALL;
+            map[this.height - 1][x] = this.tileTypes.WALL;
+        }
+        for (let y = 0; y < this.height; y++) {
+            map[y][0] = this.tileTypes.WALL;
+            map[y][this.width - 1] = this.tileTypes.WALL;
+        }
+        return map;
+    }
+}

--- a/src/commander.js
+++ b/src/commander.js
@@ -1,0 +1,16 @@
+import { Entity } from './entities.js';
+import { BattlefieldMapManager } from './battlefieldMap.js';
+
+/**
+ * 고유 ID와 개인화된 전장을 보유한 지휘관 클래스입니다.
+ */
+export class Commander extends Entity {
+    static nextCommanderId = 0;
+
+    constructor(config) {
+        super(config);
+        this.commanderId = Commander.nextCommanderId++;
+        this.battlefield = new BattlefieldMapManager(this.commanderId);
+        console.log(`지휘관 생성됨: ID = ${this.commanderId}`);
+    }
+}

--- a/src/entities.js
+++ b/src/entities.js
@@ -511,3 +511,6 @@ export class Ghost {
         this.state = 'seeking'; // 'seeking', 'possessing', 'wandering'
     }
 }
+
+// 기본 Entity 클래스를 외부에서도 사용할 수 있도록 내보냅니다.
+export { Entity };

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,33 @@
+// 게임 시작 시 사용할 기본 맵 매니저로 전장 맵을 불러옵니다.
+import { BattlefieldMapManager } from './battlefieldMap.js';
+import { Commander } from './commander.js';
+import { Entity } from './entities.js';
+
+// 데모용 간단한 월드 객체
+export const world = {
+    // 기본 월드 맵을 전장 타입으로 설정합니다.
+    map: new BattlefieldMapManager(),
+    entities: [],
+    addEntity(e) { this.entities.push(e); }
+};
+
+// Commander를 활용한 적 생성 예시
+const enemy1 = new Commander({ x: 15, y: 15, tileSize: 1, stats: { name: '적 지휘관 1' } });
+const enemy2 = new Commander({ x: 25, y: 25, tileSize: 1, stats: { name: '적 지휘관 2' } });
+world.addEntity(enemy1);
+world.addEntity(enemy2);
+
+export function startBattle(player, enemy) {
+    console.log(`${enemy.stats?.name || enemy.id}와(과) 전투 시작!`);
+    if (enemy instanceof Commander) {
+        world.map = enemy.battlefield;
+        console.log(`전장 로드: 지휘관 ID ${enemy.commanderId}의 전쟁터`);
+        player.x = 5;
+        player.y = Math.floor(world.map.height / 2);
+        enemy.x = world.map.width - 5;
+        enemy.y = Math.floor(world.map.height / 2);
+        // 전투 상태 전환 로직은 게임 시스템에 맞게 구현
+    } else {
+        // 다른 엔티티와의 전투 로직을 여기에 구현
+    }
+}


### PR DESCRIPTION
## Summary
- create `BattlefieldMapManager` for a simple wall-bordered arena
- allow exporting the base `Entity` class
- implement a `Commander` entity with a unique battlefield
- demonstrate commander usage in a minimal `src/main.js`
- use the battlefield map as the default map

## Testing
- `node run-tests.mjs` *(fails: Cannot find module 'tests/config/gameSettings.js')*

------
https://chatgpt.com/codex/tasks/task_e_68631e73a8108327a318f7fafda1e148