### PR TITLE
Simplify Aquarium map

### DIFF
--- a/src/aquariumMap.js
+++ b/src/aquariumMap.js
@@ -2,6 +2,7 @@
 // Fixed three-lane map for testing lane mechanics
 import { MapManager } from './map.js';
 import { SETTINGS } from '../config/gameSettings.js';
+import { Wall, Floor, Water, VBridge, HBridge } from './tile.js';
 
 export class AquariumMapManager extends MapManager {
     constructor(seed) {
@@ -21,74 +22,22 @@ export class AquariumMapManager extends MapManager {
 
     // 벽으로 둘러싸인 빈 맵을 생성한다
     _generateEmptyMap() {
-        const map = Array.from({ length: this.height }, () =>
-            Array(this.width).fill(this.tileTypes.FLOOR)
-        );
-
-        for (let x = 0; x < this.width; x++) {
-            map[0][x] = this.tileTypes.WALL;
-            map[this.height - 1][x] = this.tileTypes.WALL;
+        for (let i = 0; i < this._width; i++) {
+            for (let j = 0; j < this._height; j++) {
+                const key = i + "," + j;
+                if (i === 0 || i === this._width - 1 || j === 0 || j === this._height - 1) {
+                    this._mapData[key] = new Wall(i, j);
+                } else {
+                    this._mapData[key] = new Floor(i, j);
+                }
+            }
         }
-        for (let y = 0; y < this.height; y++) {
-            map[y][0] = this.tileTypes.WALL;
-            map[y][this.width - 1] = this.tileTypes.WALL;
-        }
-        return map;
     }
 
     // Generate a simple three-lane layout separated by walls. Left and right edges
     // are open so all lanes converge at the bases.
     _generateMaze() {
-        if (!this.useLanes) {
-            return super._generateEmptyMap();
-        }
-
-        const map = Array.from({ length: this.height }, () =>
-            Array(this.width).fill(this.tileTypes.WALL)
-        );
-
-        const openArea = this.openArea; // width of the bases at left and right
-        const half = Math.floor(this.corridorWidth / 2);
-        const lanes = [
-            Math.floor(this.height * 0.2),
-            Math.floor(this.height * 0.5),
-            Math.floor(this.height * 0.8)
-        ];
-        this.lanes = lanes;
-        this.laneCenters = lanes.map(l => l * this.tileSize + this.tileSize / 2);
-
-        for (let x = 0; x < this.width; x++) {
-            const isBaseColumn = x < openArea || x >= this.width - openArea;
-            for (const laneY of lanes) {
-                for (let y = laneY - half; y <= laneY + half; y++) {
-                    if (y >= 0 && y < this.height) {
-                        // lanes themselves are wide open
-                        map[y][x] = this.tileTypes.FLOOR;
-                    }
-                }
-            }
-
-            if (isBaseColumn) {
-                // also open the rest of the base columns
-                for (let y = 0; y < this.height; y++) {
-                    map[y][x] = this.tileTypes.FLOOR;
-                }
-            }
-        }
-
-        // carve jungle-style maze between lanes
-        for (let i = 0; i < lanes.length - 1; i++) {
-            const top = lanes[i] + half + 1;
-            const bottom = lanes[i + 1] - half - 1;
-            if (bottom > top) {
-                this._generateJungleZone(map, top, bottom);
-            }
-        }
-
-        // create entrances from each lane into the jungle areas
-        this._addJungleEntrances(map, lanes, half);
-
-        return map;
+        this._generateEmptyMap();
     }
 
     _generateJungleZone(map, startY, endY) {


### PR DESCRIPTION
## Summary
- add Wall and Floor imports for aquarium map
- rework `_generateEmptyMap` to populate `_mapData` with Wall and Floor tiles
- simplify `_generateMaze` to just call `_generateEmptyMap`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/2d-mount-blade/src/tile.js')*

------
https://chatgpt.com/codex/tasks/task_e_6863b76b91b08327917a27010724f82d