### PR TITLE
Simplify Aquarium map

### DIFF
--- a/src/tile.js
+++ b/src/tile.js
@@ -1,0 +1,42 @@
+export class Tile {
+    constructor(x, y, value) {
+        this.x = x;
+        this.y = y;
+        this.value = value;
+    }
+}
+
+export class Wall extends Tile {
+    constructor(x, y) {
+        super(x, y, 1);
+        this.type = 'wall';
+    }
+}
+
+export class Floor extends Tile {
+    constructor(x, y) {
+        super(x, y, 0);
+        this.type = 'floor';
+    }
+}
+
+export class Water extends Tile {
+    constructor(x, y) {
+        super(x, y, 2);
+        this.type = 'water';
+    }
+}
+
+export class VBridge extends Tile {
+    constructor(x, y) {
+        super(x, y, 3);
+        this.type = 'vbridge';
+    }
+}
+
+export class HBridge extends Tile {
+    constructor(x, y) {
+        super(x, y, 4);
+        this.type = 'hbridge';
+    }
+}


### PR DESCRIPTION
## Summary
- add new tile classes
- regenerate AquariumMap after resizing
- create a helper map data store and use it for simple empty map
- fall back to default maze during construction

## Testing
- `npm test` *(fails: Cannot find module '/workspace/2d-mount-blade/tests/config/gameSettings.js')*

------
https://chatgpt.com/codex/tasks/task_e_6863b76b91b08327917a27010724f82d