### PR TITLE
Fix GameInitializer context

### DIFF
--- a/src/legacyGame.js
+++ b/src/legacyGame.js
@@ -101,7 +101,9 @@ export class Game {
     }
 
     start() {
-        this.initializer = new GameInitializer(this);
+        // GameInitializer expects a CanvasRenderingContext2D so use the
+        // dedicated getter instead of passing the Game instance itself.
+        this.initializer = new GameInitializer(this.getBattleCanvasContext());
         this.initializer.start();
     }
 


### PR DESCRIPTION
## Summary
- pass correct canvas context to `GameInitializer`

## Testing
- `node run-tests.mjs` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686402a765fc8327bd69a213e51e9900