### PR TITLE
Use legacy Game entry and fix GameInitializer init call

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,11 +1,12 @@
 // main.js
-import { GameInitializer } from './src/core/GameInitializer.js';
+
+// legacyGame.js에 정의된 Game 클래스를 불러와 실행 진입점을 단순화한다.
+import { Game } from './src/legacyGame.js';
 import { registerServiceWorker } from './src/utils/swRegister.js';
 
 window.onload = () => {
     registerServiceWorker();
-    const canvas = document.getElementById('battleCanvas');
-    const context = canvas.getContext('2d');
-    const initializer = new GameInitializer(context);
-    initializer.start();
+    // Game 인스턴스를 생성하여 초기화 과정을 모두 맡긴다.
+    const game = new Game();
+    game.start();
 };

--- a/src/core/GameInitializer.js
+++ b/src/core/GameInitializer.js
@@ -1,8 +1,8 @@
 import { AssetLoader } from '../assetLoader.js';
-import { setupAndStartGame } from '../game.js';
 
 export class GameInitializer {
   constructor(context) {
+    // context는 Game 인스턴스로, 초기화 완료 후 init()을 호출한다.
     this.context = context;
     this.loader = new AssetLoader();
   }
@@ -57,10 +57,14 @@ export class GameInitializer {
 
     l.onReady(() => {
       console.log('에셋 로딩 완료, 게임 설정 시작...');
-      setupAndStartGame(this.context, this.loader.assets);
+      // 로딩이 끝나면 Game 인스턴스의 init을 호출해 본격적으로 게임을 시작한다.
+      this.context.init(this.loader.assets);
+
       // Ensure the canvas becomes visible once the game is ready
-      if (this.context?.canvas) {
-        this.context.canvas.style.display = 'block';
+      // battleCanvas 대신 canvas-container를 표시한다.
+      const container = document.getElementById('canvas-container');
+      if (container) {
+          container.style.display = 'block';
       }
     });
   }

--- a/src/legacyGame.js
+++ b/src/legacyGame.js
@@ -101,9 +101,8 @@ export class Game {
     }
 
     start() {
-        // GameInitializer expects a CanvasRenderingContext2D so use the
-        // dedicated getter instead of passing the Game instance itself.
-        this.initializer = new GameInitializer(this.getBattleCanvasContext());
+        // GameInitializer는 Game 인스턴스를 받아 초기화 과정을 진행한다.
+        this.initializer = new GameInitializer(this);
         this.initializer.start();
     }
 


### PR DESCRIPTION
## Summary
- load `Game` directly in `main.js` and start it
- pass the `Game` instance into `GameInitializer`
- invoke `init()` when assets finish loading and show the canvas container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686405265a948327b785df1d8c65c605