### PR TITLE
Assign assets for map rendering

### DIFF
--- a/src/legacyGame.js
+++ b/src/legacyGame.js
@@ -145,8 +145,11 @@ export class Game {
         this.statusEffectsManager = new StatusEffectsManager(this.eventManager);
         this.tagManager = new TagManager();
         this.combatCalculator = new CombatCalculator(this.eventManager, this.tagManager);
-        // 기본 맵 매니저를 생성합니다.
+        // 기본 맵 매니저를 생성하고 타일 이미지를 연결합니다.
         this.mapManager = new MapManager();
+        // mapManager.draw는 내부의 assets 객체를 사용하므로 로딩된
+        // 에셋을 즉시 할당해준다. 할당되지 않으면 맵이 검게만 보인다.
+        this.mapManager.assets = assets;
         // MovementEngine은 맵의 타일 크기를 기반으로 동작합니다.
         this.movementEngine = new MovementEngine({ tileSize: this.mapManager.tileSize });
 


### PR DESCRIPTION
## Summary
- link loaded assets to the MapManager in `legacyGame.js` so the tile graphics are drawn correctly

## Testing
- `node run-tests.mjs` *(fails: window is not defined and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_686412ff5d3c8327a97e1988400c0d9c