### PR TITLE
Fix aquarium map loading

### DIFF
--- a/src/core/LegacyGameEngine.js
+++ b/src/core/LegacyGameEngine.js
@@ -1,6 +1,7 @@
 import { EventBinder } from './EventBinder.js';
 import { MapManager } from '../map.js';
 import { ArenaMapManager } from '../arenaMap.js';
+import { AquariumMapManager } from '../aquariumMap.js';
 
 export class LegacyGameEngine {
   constructor(game) {
@@ -121,7 +122,9 @@ export class LegacyGameEngine {
     console.log(`[Game] 맵 로딩 시작: ${mapId}`);
     eventManager?.publish('before_map_load');
 
-    this.game.mapManager = mapId === 'arena' ? new ArenaMapManager() : new MapManager();
+    this.game.mapManager = mapId === 'arena'
+      ? new ArenaMapManager()
+      : (mapId === 'aquarium' ? new AquariumMapManager() : new MapManager());
     if (this.game.pathfindingManager) this.game.pathfindingManager.mapManager = this.game.mapManager;
     if (this.game.motionManager) this.game.motionManager.mapManager = this.game.mapManager;
     if (this.game.movementManager) this.game.movementManager.mapManager = this.game.mapManager;

--- a/src/map.js
+++ b/src/map.js
@@ -345,6 +345,14 @@ export class MapManager {
         return null;
     }
 
+    /**
+     * Returns a suitable starting position for the player. By default this
+     * picks a random floor tile. Subclasses may override for custom logic.
+     */
+    getPlayerStartingPosition() {
+        return this.getRandomFloorPosition() || { x: this.tileSize, y: this.tileSize };
+    }
+
     isWallAt(worldX, worldY, entityWidth = 0, entityHeight = 0) {
         const checkPoints = [
             {x: worldX, y: worldY}, {x: worldX + entityWidth, y: worldY},


### PR DESCRIPTION
## Summary
- ensure `LegacyGameEngine` loads `AquariumMapManager` when the aquarium map is requested
- add `getPlayerStartingPosition` to `MapManager`

## Testing
- `node ./run-tests.mjs`

------
https://chatgpt.com/codex/tasks/task_e_686412ff5d3c8327a97e1988400c0d9c