### PR TITLE
Implement arena map support and player spawn helper

### DIFF
--- a/src/core/LegacyGameEngine.js
+++ b/src/core/LegacyGameEngine.js
@@ -1,5 +1,6 @@
 import { EventBinder } from './EventBinder.js';
 import { MapManager } from '../map.js';
+import { ArenaMapManager } from '../arenaMap.js';
 import { AquariumMapManager } from '../aquariumMap.js';
 
 export class LegacyGameEngine {
@@ -121,7 +122,9 @@ export class LegacyGameEngine {
     console.log(`[Game] 맵 로딩 시작: ${mapId}`);
     eventManager?.publish('before_map_load');
 
-    this.game.mapManager = mapId === 'aquarium' ? new AquariumMapManager() : new MapManager();
+    this.game.mapManager = mapId === 'arena'
+      ? new ArenaMapManager()
+      : (mapId === 'aquarium' ? new AquariumMapManager() : new MapManager());
     if (this.game.pathfindingManager) this.game.pathfindingManager.mapManager = this.game.mapManager;
     if (this.game.motionManager) this.game.motionManager.mapManager = this.game.mapManager;
     if (this.game.movementManager) this.game.movementManager.mapManager = this.game.mapManager;
@@ -130,7 +133,7 @@ export class LegacyGameEngine {
     this.game.entityManager?.clearAll?.();
     this.game.factory?.createMapTiles?.(this.game.mapManager, this.game.entityManager);
 
-    if (mapId === 'aquarium') {
+    if (mapId === 'arena') {
       this.game.arenaEngine.start();
     } else {
       this.game.arenaEngine.stop();

--- a/src/map.js
+++ b/src/map.js
@@ -345,6 +345,14 @@ export class MapManager {
         return null;
     }
 
+    /**
+     * Returns a suitable starting position for the player. By default this
+     * picks a random floor tile. Subclasses may override for custom logic.
+     */
+    getPlayerStartingPosition() {
+        return this.getRandomFloorPosition() || { x: this.tileSize, y: this.tileSize };
+    }
+
     isWallAt(worldX, worldY, entityWidth = 0, entityHeight = 0) {
         const checkPoints = [
             {x: worldX, y: worldY}, {x: worldX + entityWidth, y: worldY},


### PR DESCRIPTION
## Summary
- import ArenaMapManager in game engine
- choose map manager by map id
- start arena engine only for arena maps
- expose generic `getPlayerStartingPosition` in `MapManager`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686414952f3c83278fe47865453aa6b0