### PR TITLE
Add arena map manager and spawn helper

### DIFF
--- a/src/arenaMap.js
+++ b/src/arenaMap.js
@@ -1,0 +1,26 @@
+import { MapManager } from './map.js';
+
+export class ArenaMapManager extends MapManager {
+    constructor(seed) {
+        super(seed);
+    }
+
+    // Generate a mostly open space surrounded by walls
+    _generateMaze() {
+        const width = 20;
+        const height = 20;
+        this.width = width;
+        this.height = height;
+        const map = Array.from({ length: height }, () => Array(width).fill(this.tileTypes.FLOOR));
+
+        // Add boundary walls
+        for (let y = 0; y < height; y++) {
+            for (let x = 0; x < width; x++) {
+                if (y === 0 || y === height - 1 || x === 0 || x === width - 1) {
+                    map[y][x] = this.tileTypes.WALL;
+                }
+            }
+        }
+        return map;
+    }
+}

--- a/src/core/LegacyGameEngine.js
+++ b/src/core/LegacyGameEngine.js
@@ -1,5 +1,6 @@
 import { EventBinder } from './EventBinder.js';
 import { MapManager } from '../map.js';
+import { ArenaMapManager } from '../arenaMap.js';
 import { AquariumMapManager } from '../aquariumMap.js';
 
 export class LegacyGameEngine {
@@ -121,7 +122,9 @@ export class LegacyGameEngine {
     console.log(`[Game] 맵 로딩 시작: ${mapId}`);
     eventManager?.publish('before_map_load');
 
-    this.game.mapManager = mapId === 'aquarium' ? new AquariumMapManager() : new MapManager();
+    this.game.mapManager = mapId === 'arena'
+      ? new ArenaMapManager()
+      : (mapId === 'aquarium' ? new AquariumMapManager() : new MapManager());
     if (this.game.pathfindingManager) this.game.pathfindingManager.mapManager = this.game.mapManager;
     if (this.game.motionManager) this.game.motionManager.mapManager = this.game.mapManager;
     if (this.game.movementManager) this.game.movementManager.mapManager = this.game.mapManager;
@@ -130,7 +133,7 @@ export class LegacyGameEngine {
     this.game.entityManager?.clearAll?.();
     this.game.factory?.createMapTiles?.(this.game.mapManager, this.game.entityManager);
 
-    if (mapId === 'aquarium') {
+    if (mapId === 'arena') {
       this.game.arenaEngine.start();
     } else {
       this.game.arenaEngine.stop();

--- a/src/map.js
+++ b/src/map.js
@@ -345,6 +345,14 @@ export class MapManager {
         return null;
     }
 
+    /**
+     * Returns a suitable starting position for the player. By default this
+     * picks a random floor tile. Subclasses may override for custom logic.
+     */
+    getPlayerStartingPosition() {
+        return this.getRandomFloorPosition() || { x: this.tileSize, y: this.tileSize };
+    }
+
     isWallAt(worldX, worldY, entityWidth = 0, entityHeight = 0) {
         const checkPoints = [
             {x: worldX, y: worldY}, {x: worldX + entityWidth, y: worldY},


### PR DESCRIPTION
## Summary
- create `ArenaMapManager` for simple arena map generation
- support selecting `ArenaMapManager` when loading the 'arena' map
- fall back to player spawn helper in `MapManager`

## Testing
- `npm test` *(fails: tf.sequential is not a function, addEntity not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686414952f3c83278fe47865453aa6b0